### PR TITLE
(hotfix) Fix logic to add gpt prompt messages

### DIFF
--- a/backend/moment/writing/utils.py
+++ b/backend/moment/writing/utils.py
@@ -80,7 +80,6 @@ class GPTAgent:
     @timeout
     def _call(self, container: dict):
         messages = self._messages
-        self.reset_messages()
         completion = openai.ChatCompletion.create(
             model=self.model,
             messages=messages,

--- a/backend/moment/writing/views.py
+++ b/backend/moment/writing/views.py
@@ -46,6 +46,7 @@ class MomentView(GenericAPIView):
         body.is_valid(raise_exception=True)
         user = User.objects.get(pk=request.user.id)
 
+        self.gpt_agent.reset_messages()
         self.gpt_agent.add_message(body.data["moment"])
 
         try:


### PR DESCRIPTION
gpt prompt를 구성하는 로직에서 문제를 발견해서 고쳤습니다.
기존 로직대로라면 api call이 반복될 때마다 prompt가 계속 list 형태로 누적됩니다.
매번 call 때마다 prompt를 reset 하고 새로 구성하도록 수정했습니다.