### PR TITLE
Frontend/A5: 날짜 바뀔 때 새로고침 처리

### DIFF
--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/WriteViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/WriteViewFragment.java
@@ -9,12 +9,10 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
-import androidx.viewpager2.adapter.FragmentStateAdapter;
 import androidx.viewpager2.widget.ViewPager2;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import snu.swpp.moment.LoginRegisterActivity;
-import snu.swpp.moment.MainActivity;
 import snu.swpp.moment.data.repository.AuthenticationRepository;
 import snu.swpp.moment.databinding.FragmentWriteviewBinding;
 import snu.swpp.moment.ui.main_writeview.slideview.SlideViewAdapter;
@@ -28,8 +26,7 @@ public class WriteViewFragment extends Fragment {
     private FragmentWriteviewBinding binding;
 
     // ViewPager variables
-    private ViewPager2 mPager;
-    private FragmentStateAdapter pagerAdapter;
+    private SlideViewAdapter slideViewAdapter;
     private final Handler slideHandler = new Handler(); // 슬라이드를 자동으로 변경하는 Handler
 
     private AuthenticationRepository authenticationRepository;
@@ -51,41 +48,27 @@ public class WriteViewFragment extends Fragment {
         View root = binding.getRoot();
 
         // 여기부터 slide가 가능해짐
-        mPager = binding.viewpager;
-        pagerAdapter = new SlideViewAdapter(WriteViewFragment.this, num_page);
-        mPager.setAdapter(pagerAdapter);
-        mPager.setOrientation(ViewPager2.ORIENTATION_HORIZONTAL);
+        slideViewAdapter = new SlideViewAdapter(WriteViewFragment.this, num_page);
+        binding.viewpager.setAdapter(slideViewAdapter);
+        binding.viewpager.setOrientation(ViewPager2.ORIENTATION_HORIZONTAL);
         // 최초의 페이지 설정은 이거로 함 (numpage 보다 크면 마지막페이지가 세팅되는듯 - 아래 onPageChangeCallBack)
-        mPager.setCurrentItem(num_page, false);
+        binding.viewpager.setCurrentItem(num_page, false);
         // offscreen 몇 페이지가 로드되어 있을지 설정 (Latency 감소)
-        mPager.setOffscreenPageLimit(3);
+        binding.viewpager.setOffscreenPageLimit(3);
 
-        mPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
+        binding.viewpager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
             @Override
             public void onPageScrolled(int position, float positionOffset,
                 int positionOffsetPixels) {
                 super.onPageScrolled(position, positionOffset, positionOffsetPixels);
 
                 if (positionOffsetPixels == 0) {
-                    int index = position;
                     if (position >= num_page) { // 마지막 페이지에서 오른쪽으로 넘어갈 때 마지막 페이지로 고정
-                        index = num_page - 1;
-                        mPager.setCurrentItem(num_page - 1, false);
+                        binding.viewpager.setCurrentItem(num_page - 1, false);
                     } else if (position < 0) { // 첫 페이지에서 왼쪽으로 넘어갈 때 첫 페이지로 고정
-                        index = 0;
-                        mPager.setCurrentItem(0, false);
+                        binding.viewpager.setCurrentItem(0, false);
                     }
-                    LocalDate pageDate = TimeConverter.getToday().minusDays(num_page - index - 1);
-                    String formattedDate = TimeConverter.formatLocalDate(pageDate, "yyyy. MM. dd.");
-                    MainActivity activity = (MainActivity) getActivity();
-                    activity.setToolbarTitle(formattedDate);
                 }
-            }
-
-            @Override
-            public void onPageSelected(int position) {
-                super.onPageSelected(position);
-                //mIndicator.animatePageSelected(position % 4);
             }
         });
 
@@ -106,7 +89,6 @@ public class WriteViewFragment extends Fragment {
 
         int dayDiff = (int) ChronoUnit.DAYS.between(created_at, today);
         this.num_page = dayDiff + 1;
-
     }
 
     @Override

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -16,13 +16,13 @@ public abstract class BaseWritePageFragment extends Fragment {
     public void setToolbarTitle() {
         MainActivity mainActivity = (MainActivity) getActivity();
         if (mainActivity != null) {
-            mainActivity.setToolbarTitle(getToolbarTitle());
+            mainActivity.setToolbarTitle(getDateText());
         } else {
             throw new RuntimeException("MainActivity is null");
         }
     }
 
-    public abstract String getToolbarTitle();
+    public abstract String getDateText();
 
     protected void updateRefreshTime() {
         lastRefreshedTime = LocalDateTime.now();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -1,0 +1,45 @@
+package snu.swpp.moment.ui.main_writeview.slideview;
+
+import android.os.Handler;
+import android.util.Log;
+import androidx.fragment.app.Fragment;
+import java.time.LocalDateTime;
+import snu.swpp.moment.MainActivity;
+
+public abstract class BaseWritePageFragment extends Fragment {
+
+    protected final Handler refreshHandler = new Handler();
+    protected LocalDateTime lastRefreshedTime = LocalDateTime.now();
+    protected final long REFRESH_INTERVAL = 1000 * 60 * 10;   // 10 minutes
+    protected final int STARTING_HOUR = 3;
+
+    public void setToolbarTitle() {
+        MainActivity mainActivity = (MainActivity) getActivity();
+        if (mainActivity != null) {
+            mainActivity.setToolbarTitle(getToolbarTitle());
+        } else {
+            throw new RuntimeException("MainActivity is null");
+        }
+    }
+
+    public abstract String getToolbarTitle();
+
+    protected void updateRefreshTime() {
+        lastRefreshedTime = LocalDateTime.now();
+    }
+
+    protected boolean isOutdated() {
+        LocalDateTime now = LocalDateTime.now();
+        if (lastRefreshedTime.getDayOfMonth() == now.getDayOfMonth()) {
+            return false;
+        }
+        return now.getHour() >= STARTING_HOUR;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        Log.d("BaseWritePageFragment", "onResume");
+        setToolbarTitle();
+    }
+}

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -13,6 +13,16 @@ public abstract class BaseWritePageFragment extends Fragment {
     protected final long REFRESH_INTERVAL = 1000 * 60 * 10;   // 10 minutes
     protected final int STARTING_HOUR = 3;
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        setToolbarTitle();
+        if (isOutdated()) {
+            Log.d("BaseWritePageFragment", "Outdated, refreshing...");
+            callApisToRefresh();
+        }
+    }
+
     public void setToolbarTitle() {
         MainActivity mainActivity = (MainActivity) getActivity();
         if (mainActivity != null) {
@@ -22,7 +32,9 @@ public abstract class BaseWritePageFragment extends Fragment {
         }
     }
 
-    public abstract String getDateText();
+    protected abstract void callApisToRefresh();
+
+    protected abstract String getDateText();
 
     protected void updateRefreshTime() {
         lastRefreshedTime = LocalDateTime.now();
@@ -34,12 +46,5 @@ public abstract class BaseWritePageFragment extends Fragment {
             return false;
         }
         return now.getHour() >= STARTING_HOUR;
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        Log.d("BaseWritePageFragment", "onResume");
-        setToolbarTitle();
     }
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -192,6 +192,7 @@ public class DailyViewFragment extends Fragment {
                     Log.d("DailyViewFragment", "run: Reloading fragment");
                     viewModel.getMoment(now);
                     viewModel.getStory(now);
+                    listViewAdapter.notifyDataSetChanged(false);
                     updateRefreshTime();
                 }
                 refreshHandler.postDelayed(this, REFRESH_INTERVAL);

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -101,7 +101,7 @@ public class DailyViewFragment extends BaseWritePageFragment {
         listViewItems = new ArrayList<>();
         listViewAdapter = new ListViewAdapter(getContext(), listViewItems);
         listViewAdapter.setAnimation(false);
-        
+
         binding.dailyMomentList.setAdapter(listViewAdapter);
         View footerView = LayoutInflater.from(getContext())
             .inflate(R.layout.listview_footer, null, false);
@@ -181,6 +181,7 @@ public class DailyViewFragment extends BaseWritePageFragment {
                 // 하루가 지났을 때
                 if (isOutdated()) {
                     Log.d("DailyViewFragment", "run: Reloading fragment");
+                    setToolbarTitle();
                     callApisToRefresh();
                     updateRefreshTime();
                 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -119,8 +119,7 @@ public class DailyViewFragment extends BaseWritePageFragment {
                     for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
                         listViewItems.add(new ListViewItem(momentPair));
                     }
-
-                    listViewAdapter.notifyDataSetChanged(false);
+                    listViewAdapter.notifyDataSetChanged();
                 } else {
                     binding.noMomentText.setVisibility(View.VISIBLE);
                 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -105,10 +105,9 @@ public class DailyViewFragment extends Fragment {
 
         listViewItems = new ArrayList<>();
 
-        LocalDate date = TimeConverter.getToday().minusDays(minusDays);
-        LocalDateTime dateTime = date.atTime(3, 0);
-        viewModel.getMoment(dateTime);
-        viewModel.getStory(dateTime);
+        LocalDateTime currentDateTime = getCurrentDateTime();
+        viewModel.getMoment(currentDateTime);
+        viewModel.getStory(currentDateTime);
 
         viewModel.observeMomentState((MomentUiState momentUiState) -> {
             Exception error = momentUiState.getError();
@@ -184,14 +183,14 @@ public class DailyViewFragment extends Fragment {
         Runnable refreshRunnable = new Runnable() {
             @Override
             public void run() {
-                LocalDateTime now = LocalDateTime.now();
-                Log.d("DailyViewFragment", String.format("run: %s", now));
+                Log.d("DailyViewFragment", String.format("run: %s", LocalDateTime.now()));
 
                 // 하루가 지났을 때
                 if (isOutdated()) {
                     Log.d("DailyViewFragment", "run: Reloading fragment");
-                    viewModel.getMoment(now);
-                    viewModel.getStory(now);
+                    LocalDateTime currentDateTime = getCurrentDateTime();
+                    viewModel.getMoment(currentDateTime);
+                    viewModel.getStory(currentDateTime);
                     listViewAdapter.notifyDataSetChanged(false);
                     updateRefreshTime();
                 }
@@ -215,6 +214,12 @@ public class DailyViewFragment extends Fragment {
             return false;
         }
         return now.getHour() >= 3;
+    }
+
+    private LocalDateTime getCurrentDateTime() {
+        LocalDate date = TimeConverter.getToday().minusDays(minusDays);
+        LocalDateTime current = date.atTime(3, 0, 0);
+        return current;
     }
 
     @Override

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -199,7 +199,7 @@ public class DailyViewFragment extends BaseWritePageFragment {
     }
 
     @Override
-    public String getToolbarTitle() {
+    public String getDateText() {
         LocalDate date = getCurrentDateTime().toLocalDate();
         return TimeConverter.formatLocalDate(date, "yyyy. MM. dd.");
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -2,13 +2,11 @@ package snu.swpp.moment.ui.main_writeview.slideview;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Toast;
-import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,15 +25,15 @@ import snu.swpp.moment.databinding.DailyItemBinding;
 import snu.swpp.moment.exception.NoInternetException;
 import snu.swpp.moment.exception.UnauthorizedAccessException;
 import snu.swpp.moment.ui.main_writeview.component.ListFooterContainer;
+import snu.swpp.moment.ui.main_writeview.uistate.MomentUiState;
+import snu.swpp.moment.ui.main_writeview.uistate.StoryUiState;
 import snu.swpp.moment.ui.main_writeview.viewmodel.DailyViewModel;
 import snu.swpp.moment.ui.main_writeview.viewmodel.DailyViewModelFactory;
 import snu.swpp.moment.ui.main_writeview.viewmodel.GetStoryUseCase;
 import snu.swpp.moment.ui.main_writeview.viewmodel.SaveScoreUseCase;
-import snu.swpp.moment.ui.main_writeview.uistate.MomentUiState;
-import snu.swpp.moment.ui.main_writeview.uistate.StoryUiState;
 import snu.swpp.moment.utils.TimeConverter;
 
-public class DailyViewFragment extends Fragment {
+public class DailyViewFragment extends BaseWritePageFragment {
 
     private int minusDays;
 
@@ -53,10 +51,6 @@ public class DailyViewFragment extends Fragment {
     private AuthenticationRepository authenticationRepository;
 
     private ListFooterContainer listFooterContainer;
-
-    private final Handler refreshHandler = new Handler();
-    private final long REFRESH_INTERVAL = 1000 * 60 * 10;   // 10 minutes
-    private LocalDateTime lastRefreshedTime = LocalDateTime.now();
 
     public static DailyViewFragment initialize(int minusDays) {
         Log.d("DailyViewFragment", "Initializing DailyViewFragment with minusDays: " + minusDays);
@@ -204,16 +198,10 @@ public class DailyViewFragment extends Fragment {
         return root;
     }
 
-    private void updateRefreshTime() {
-        lastRefreshedTime = LocalDateTime.now();
-    }
-
-    private boolean isOutdated() {
-        LocalDateTime now = LocalDateTime.now();
-        if (lastRefreshedTime.getDayOfMonth() == now.getDayOfMonth()) {
-            return false;
-        }
-        return now.getHour() >= 3;
+    @Override
+    public String getToolbarTitle() {
+        LocalDate date = getCurrentDateTime().toLocalDate();
+        return TimeConverter.formatLocalDate(date, "yyyy. MM. dd.");
     }
 
     private LocalDateTime getCurrentDateTime() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -97,11 +97,17 @@ public class DailyViewFragment extends BaseWritePageFragment {
         binding = DailyItemBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
 
+        // ListView setup
         listViewItems = new ArrayList<>();
+        listViewAdapter = new ListViewAdapter(getContext(), listViewItems);
+        listViewAdapter.setAnimation(false);
+        
+        binding.dailyMomentList.setAdapter(listViewAdapter);
+        View footerView = LayoutInflater.from(getContext())
+            .inflate(R.layout.listview_footer, null, false);
+        binding.dailyMomentList.addFooterView(footerView);
 
-        LocalDateTime currentDateTime = getCurrentDateTime();
-        viewModel.getMoment(currentDateTime);
-        viewModel.getStory(currentDateTime);
+        callApisToRefresh();
 
         viewModel.observeMomentState((MomentUiState momentUiState) -> {
             Exception error = momentUiState.getError();
@@ -134,12 +140,6 @@ public class DailyViewFragment extends BaseWritePageFragment {
                     .show();
             }
         });
-
-        listViewAdapter = new ListViewAdapter(getContext(), listViewItems);
-        binding.dailyMomentList.setAdapter(listViewAdapter);
-        View footerView = LayoutInflater.from(getContext())
-            .inflate(R.layout.listview_footer, null, false);
-        binding.dailyMomentList.addFooterView(footerView);
 
         // list footer 관리 객체 초기화
         listFooterContainer = new ListFooterContainer(footerView);
@@ -182,10 +182,7 @@ public class DailyViewFragment extends BaseWritePageFragment {
                 // 하루가 지났을 때
                 if (isOutdated()) {
                     Log.d("DailyViewFragment", "run: Reloading fragment");
-                    LocalDateTime currentDateTime = getCurrentDateTime();
-                    viewModel.getMoment(currentDateTime);
-                    viewModel.getStory(currentDateTime);
-                    listViewAdapter.notifyDataSetChanged(false);
+                    callApisToRefresh();
                     updateRefreshTime();
                 }
                 refreshHandler.postDelayed(this, REFRESH_INTERVAL);
@@ -199,7 +196,14 @@ public class DailyViewFragment extends BaseWritePageFragment {
     }
 
     @Override
-    public String getDateText() {
+    protected void callApisToRefresh() {
+        LocalDateTime currentDateTime = getCurrentDateTime();
+        viewModel.getMoment(currentDateTime);
+        viewModel.getStory(currentDateTime);
+    }
+
+    @Override
+    protected String getDateText() {
         LocalDate date = getCurrentDateTime().toLocalDate();
         return TimeConverter.formatLocalDate(date, "yyyy. MM. dd.");
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/ListViewAdapter.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/ListViewAdapter.java
@@ -91,10 +91,8 @@ public class ListViewAdapter extends BaseAdapter {
         return convertView;
     }
 
-    public void notifyDataSetChanged(boolean withAnimation) {
-        isShowingAnimation = withAnimation;
-        notifyDataSetChanged();
-        isShowingAnimation = true;
+    public void setAnimation(boolean set) {
+        isShowingAnimation = set;
     }
 
     public boolean getWaitingAiReplySwitch() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/SlideViewAdapter.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/SlideViewAdapter.java
@@ -16,7 +16,7 @@ public class SlideViewAdapter extends FragmentStateAdapter {
 
     @NonNull
     @Override
-    public Fragment createFragment(int position) {
+    public BaseWritePageFragment createFragment(int position) {
         int index = getRealPosition(position);
         if (index == count - 1) {
             return new TodayViewFragment();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -302,7 +302,7 @@ public class TodayViewFragment extends BaseWritePageFragment {
     }
 
     @Override
-    public String getToolbarTitle() {
+    public String getDateText() {
         LocalDate today = LocalDate.now();
         return TimeConverter.formatLocalDate(today, "yyyy. MM. dd.");
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -2,7 +2,6 @@ package snu.swpp.moment.ui.main_writeview.slideview;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,8 +10,8 @@ import android.widget.Toast;
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -33,14 +32,15 @@ import snu.swpp.moment.exception.NoInternetException;
 import snu.swpp.moment.exception.UnauthorizedAccessException;
 import snu.swpp.moment.ui.main_writeview.component.BottomButtonContainer;
 import snu.swpp.moment.ui.main_writeview.component.ListFooterContainer;
+import snu.swpp.moment.ui.main_writeview.uistate.StoryUiState;
 import snu.swpp.moment.ui.main_writeview.viewmodel.GetStoryUseCase;
 import snu.swpp.moment.ui.main_writeview.viewmodel.SaveScoreUseCase;
 import snu.swpp.moment.ui.main_writeview.viewmodel.TodayViewModel;
 import snu.swpp.moment.ui.main_writeview.viewmodel.TodayViewModelFactory;
-import snu.swpp.moment.ui.main_writeview.uistate.StoryUiState;
 import snu.swpp.moment.utils.KeyboardUtils;
+import snu.swpp.moment.utils.TimeConverter;
 
-public class TodayViewFragment extends Fragment {
+public class TodayViewFragment extends BaseWritePageFragment {
 
     private TodayItemBinding binding;
     private List<ListViewItem> listViewItems;
@@ -58,10 +58,6 @@ public class TodayViewFragment extends Fragment {
     private StoryRemoteDataSource storyRemoteDataSource;
     private GetStoryUseCase getStoryUseCase;
     private SaveScoreUseCase saveScoreUseCase;
-
-    private final Handler refreshHandler = new Handler();
-    private final long REFRESH_INTERVAL = 1000 * 60 * 10;   // 10 minutes
-    private LocalDateTime lastRefreshedTime = LocalDateTime.now();
 
     private final int MOMENT_HOUR_LIMIT = 2;
 
@@ -305,21 +301,15 @@ public class TodayViewFragment extends Fragment {
         return root;
     }
 
+    @Override
+    public String getToolbarTitle() {
+        LocalDate today = LocalDate.now();
+        return TimeConverter.formatLocalDate(today, "yyyy. MM. dd.");
+    }
+
     private void scrollToBottom() {
         binding.todayMomentList.post(() -> binding.todayMomentList.smoothScrollToPosition(
             binding.todayMomentList.getCount() - 1));
-    }
-
-    private void updateRefreshTime() {
-        lastRefreshedTime = LocalDateTime.now();
-    }
-
-    private boolean isOutdated() {
-        LocalDateTime now = LocalDateTime.now();
-        if (lastRefreshedTime.getDayOfMonth() == now.getDayOfMonth()) {
-            return false;
-        }
-        return now.getHour() >= 3;
     }
 
     @Override

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -291,6 +291,7 @@ public class TodayViewFragment extends Fragment {
                     Log.d("TodayViewFragment", "run: Reloading fragment");
                     viewModel.getMoment(now);
                     viewModel.getStory(now);
+                    listViewAdapter.notifyDataSetChanged(false);
                     updateRefreshTime();
                 }
                 refreshHandler.postDelayed(this, REFRESH_INTERVAL);

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -225,7 +225,7 @@ public class TodayViewFragment extends BaseWritePageFragment {
                 if (numMoments > 0) {
                     listViewItems.clear();
                     listViewAdapter.setAnimation(false);
-                    
+
                     for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
                         listViewItems.add(new ListViewItem(momentPair));
                     }
@@ -288,6 +288,7 @@ public class TodayViewFragment extends BaseWritePageFragment {
                 // 하루가 지났고 하루 마무리 진행 중이 아닐 때
                 if (isOutdated() && !listFooterContainer.isCompletionInProgress()) {
                     Log.d("TodayViewFragment", "run: Reloading fragment");
+                    setToolbarTitle();
                     callApisToRefresh();
                     updateRefreshTime();
                 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -244,7 +244,6 @@ public class TodayViewFragment extends BaseWritePageFragment {
             }
 
         });
-        viewModel.getMoment(LocalDateTime.now());
 
         // story GET API 호출 후 동작
         viewModel.observeSavedStoryState((StoryUiState savedStoryState) -> {
@@ -273,7 +272,8 @@ public class TodayViewFragment extends BaseWritePageFragment {
                     .show();
             }
         });
-        viewModel.getStory(LocalDateTime.now());
+
+        callApisToRefresh();
 
         // 날짜 변화 확인해서 GET API 다시 호출
         Runnable refreshRunnable = new Runnable() {
@@ -285,9 +285,7 @@ public class TodayViewFragment extends BaseWritePageFragment {
                 // 하루가 지났고 하루 마무리 진행 중이 아닐 때
                 if (isOutdated() && !listFooterContainer.isCompletionInProgress()) {
                     Log.d("TodayViewFragment", "run: Reloading fragment");
-                    viewModel.getMoment(now);
-                    viewModel.getStory(now);
-                    listViewAdapter.notifyDataSetChanged(false);
+                    callApisToRefresh();
                     updateRefreshTime();
                 }
                 refreshHandler.postDelayed(this, REFRESH_INTERVAL);
@@ -302,7 +300,14 @@ public class TodayViewFragment extends BaseWritePageFragment {
     }
 
     @Override
-    public String getDateText() {
+    protected void callApisToRefresh() {
+        LocalDateTime now = LocalDateTime.now();
+        viewModel.getMoment(now);
+        viewModel.getStory(now);
+    }
+
+    @Override
+    protected String getDateText() {
         LocalDate today = LocalDate.now();
         return TimeConverter.formatLocalDate(today, "yyyy. MM. dd.");
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -141,8 +141,9 @@ public class TodayViewFragment extends BaseWritePageFragment {
                 // 새 item 추가
                 // 이때 footer의 변화는 아래에서 ListViewAdapter에 등록하는 observer가 처리
                 viewModel.writeMoment(text);
+                listViewAdapter.setAnimation(true);
                 listViewItems.add(new ListViewItem(text, new Date()));
-                listViewAdapter.notifyDataSetChanged(true);
+                listViewAdapter.notifyDataSetChanged();
                 scrollToBottom();
             }
         });
@@ -223,11 +224,13 @@ public class TodayViewFragment extends BaseWritePageFragment {
 
                 if (numMoments > 0) {
                     listViewItems.clear();
+                    listViewAdapter.setAnimation(false);
+                    
                     for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
                         listViewItems.add(new ListViewItem(momentPair));
                     }
 
-                    listViewAdapter.notifyDataSetChanged(false);
+                    listViewAdapter.notifyDataSetChanged();
                     scrollToBottom();
                 }
             } else if (error instanceof NoInternetException) {


### PR DESCRIPTION
### Frontend/A5: 날짜 바뀔 때 새로고침 처리

#### PR Description: 
3시를 지날 때 view를 새로고침 하는 로직을 보강했습니다.
* `DailyViewFragment`에서 새로고침을 위해 API를 부를 때 날짜를 잘못 넣어주고 있었어서 고쳤습니다.
* 새로고침 시에 툴바의 날짜 텍스트를 다시 만들어주는 부분을 빠뜨려서 추가했습니다.
  - 이제 툴바의 날짜 텍스트는 view pager의 listener 안에서 처리하지 않고, 각 fragment의 `onResume()` 안에서 처리합니다.
* 10분마다 검사하는 것 외에도, 좌우로 스와이플 할 때마다 outdated인지 확인해서 다시 API를 부르도록 했습니다. 역시 `onResume()` 안에서 처리합니다.

#### Additional Comments: 
이제 `TodayViewFragment`와 `DailyViewFragment`가 `BaseWritePageFragment`를 상속합니다.