### PR TITLE
backend/story_fix Enable blank inputs when posting story

### DIFF
--- a/backend/moment/writing/serializers.py
+++ b/backend/moment/writing/serializers.py
@@ -71,8 +71,8 @@ class StoryQuerySerializer(serializers.Serializer):
 
 
 class StoryCreateSerializer(serializers.Serializer):
-    title = serializers.CharField(max_length=STORY_TITLE_MAX_LENGTH)
-    content = serializers.CharField(max_length=STORY_MAX_LENGTH)
+    title = serializers.CharField(max_length=STORY_TITLE_MAX_LENGTH, allow_blank=True)
+    content = serializers.CharField(max_length=STORY_MAX_LENGTH, allow_blank=True)
 
 
 class StoryDeleteSerializer(serializers.Serializer):


### PR DESCRIPTION
### PR Title: Enable blank inputs when posting story

#### PR Description: 
Story post에서 title 혹은 content가 빈칸일때도 잘 동작하도록 serializer를 수정했습니다.

#### Additional Comments: 
None