### PR TITLE
Frontend/A6: 쓰기탭 자동 새로고침 오류 해결

### DIFF
--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/MainActivity.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends AppCompatActivity {
 
     private TextView toolbarTitle;
 
-    private MutableLiveData<LocalDate> writeDestinationDate = new MutableLiveData<>();
+    private final MutableLiveData<LocalDate> writeDestinationDate = new MutableLiveData<>();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/model/LoggedInUserModel.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/model/LoggedInUserModel.java
@@ -9,11 +9,11 @@ import snu.swpp.moment.api.response.RegisterResponse;
  */
 public class LoggedInUserModel {
 
-    private String username;
-    private String nickName;
-    private String createAt;
-    private String AccessToken;
-    private String RefreshToken;
+    private final String username;
+    private final String nickName;
+    private final String createAt;
+    private final String AccessToken;
+    private final String RefreshToken;
 
     public LoggedInUserModel(RegisterResponse.User user, RegisterResponse.Token token) {
         this.username = user.getUsername();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/login/LoggedInUserState.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/login/LoggedInUserState.java
@@ -12,7 +12,7 @@ class LoggedInUserState {
         this.nickname = nickname;
     }
 
-    String getDisplayName() {
+    String getNickname() {
         return nickname;
     }
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_monthview/MonthViewFragment.kt
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_monthview/MonthViewFragment.kt
@@ -168,7 +168,7 @@ class MonthViewFragment : Fragment() {
 
         binding.daySummaryContainer.dayNavigateButton.isActivated = true
         binding.daySummaryContainer.dayNavigateButton.setOnClickListener {
-            Log.d("MonthViewFragment", "navigate button clicked");
+            Log.d("MonthViewFragment", "navigate button clicked")
             (requireActivity() as MainActivity).navigateToWriteViewPage(viewModel.getSelectedDate())
         }
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_monthview/MonthViewModel.kt
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_monthview/MonthViewModel.kt
@@ -54,10 +54,10 @@ class MonthViewModel(
 
     fun getStory(month: YearMonth) {
         //  api 부르고 MonthStoryState 업데이트
-        val startEndTimes = TimeConverter.getOneMonthTimestamps(month);
+        val startEndTimes = TimeConverter.getOneMonthTimestamps(month)
         authenticationRepository.isTokenValid(object : TokenCallBack {
             override fun onSuccess() {
-                val accessToken = authenticationRepository.token.accessToken;
+                val accessToken = authenticationRepository.token.accessToken
                 storyRepository.getStory(accessToken, startEndTimes[0], startEndTimes[1],
                     object : StoryGetCallBack {
                         override fun onSuccess(storyList: MutableList<StoryModel>) {
@@ -65,7 +65,7 @@ class MonthViewModel(
                                 storyList.map { CalendarDayState.fromStoryModel(it) }
                             val datInfoStateList = fillEmptyStory(calendarDayStateList, month)
                             monthChangedSwitch = true
-                            calendarMonthState.value = CalendarMonthState(null, datInfoStateList);
+                            calendarMonthState.value = CalendarMonthState(null, datInfoStateList)
                         }
 
                         override fun onFailure(error: Exception) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/WriteViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/WriteViewFragment.java
@@ -116,7 +116,7 @@ public class WriteViewFragment extends Fragment {
         LocalDate today = TimeConverter.getToday();
         LocalDate createdAt = LocalDate.parse(dateInString.substring(0, 10));
         int hour = Integer.parseInt(dateInString.substring(11, 13));
-        createdAt = TimeConverter.updateDateFromThree(createdAt, hour);
+        createdAt = TimeConverter.adjustToServiceDate(createdAt, hour);
 
         return (int) ChronoUnit.DAYS.between(createdAt, today) + 1;
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/BottomButtonContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/BottomButtonContainer.java
@@ -28,27 +28,27 @@ public class BottomButtonContainer {
         this.listFooterContainer = listFooterContainer;
 
         this.listFooterContainer.observeBottomButtonState((Boolean state) -> {
-            setActivated(state);
             Log.d("BottomButtonContainer", "observeBottomButtonState: " + state);
+            setActivated(state, false);
         });
+
+        viewingMoment();
     }
 
     public void setActivated(boolean activated, boolean completed) {
-        setActivated(activated);
-        if (completed) {
-            button.setText(R.string.completed_day);
-        }
         Log.d("BottomButtonContainer", "setActivated: " + activated + ", " + completed);
+        setActivated(activated);
+        button.setText(completed ? R.string.completed_day : R.string.day_complete_string);
     }
 
     public void setActivated(boolean activated) {
+        Log.d("BottomButtonContainer", "setActivated: " + activated);
         button.setActivated(activated);
         button.setEnabled(activated);
-        Log.d("BottomButtonContainer", "setActivated: " + activated);
     }
 
     /* 모먼트 작성 중: 하루 마무리하기 버튼 */
-    public void viewingMoment() {
+    private void viewingMoment() {
         button.setText(R.string.day_complete_string);
 
         button.setOnClickListener(v -> {
@@ -70,7 +70,7 @@ public class BottomButtonContainer {
     }
 
     /* 스토리 작성 중: 다음 단계로 이동 버튼 */
-    public void writingStory() {
+    private void writingStory() {
         listFooterContainer.setUiWritingStory();
 
         button.setText(R.string.next_stage_button);
@@ -83,7 +83,7 @@ public class BottomButtonContainer {
     }
 
     /* 감정 선택 중: 다음 단계로 이동 버튼 */
-    public void selectingEmotion() {
+    private void selectingEmotion() {
         listFooterContainer.setUiSelectingEmotion();
         listFooterContainer.freezeStoryEditText();
 
@@ -95,7 +95,7 @@ public class BottomButtonContainer {
         });
     }
 
-    public void writingTags() {
+    private void writingTags() {
         listFooterContainer.setUiWritingTags();
         listFooterContainer.freezeEmotionSelector();
 
@@ -107,7 +107,7 @@ public class BottomButtonContainer {
         });
     }
 
-    public void completionDone() {
+    private void completionDone() {
         listFooterContainer.setUiSelectingScore();
         listFooterContainer.freezeTagEditText();
 
@@ -117,12 +117,13 @@ public class BottomButtonContainer {
     public Observer<Boolean> waitingAiReplySwitchObserver() {
         // ListViewAdapter가 가지고 있는 LiveData에 등록해서 사용
         return (Boolean isWaitingAiReply) -> {
+            Log.d("BottomButtonContainer", "waitingAiReplySwitchObserver: " + isWaitingAiReply);
             if (isWaitingAiReply) {
                 setActivated(false);
                 listFooterContainer.setUiWaitingAiReply();
             } else {
                 setActivated(true);
-                listFooterContainer.setUiReadyToAddMoment();
+                listFooterContainer.setUiReadyToAddMoment(true);
             }
         };
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/EmotionGridContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/EmotionGridContainer.java
@@ -51,7 +51,8 @@ public class EmotionGridContainer {
             final int _i = i;
             textButton.setOnClickListener(v -> {
                 int previousSelectedEmotion = selectedEmotion.getValue();
-                if (previousSelectedEmotion > -1) {
+                if (0 <= previousSelectedEmotion
+                    && previousSelectedEmotion < textButtonList.size()) {
                     TextView previousButton = textButtonList.get(previousSelectedEmotion);
                     previousButton.setTypeface(maruburiLight);
                     previousButton.setTextColor(colorBlack);
@@ -81,13 +82,13 @@ public class EmotionGridContainer {
         textButton.performClick();
     }
 
-    public void setSelectedEmotionObserver(Observer<Integer> observer) {
+    public void observeSelectedEmotion(Observer<Integer> observer) {
         selectedEmotion.observeForever(observer);
     }
 
     public void resetUi() {
         freeze(false);
-        selectedEmotion.setValue(-1);
+        selectedEmotion.setValue(EmotionMap.INVALID_EMOTION);
         for (TextView textButton : textButtonList) {
             textButton.setTypeface(maruburiLight);
             textButton.setTextColor(colorBlack);

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/EmotionGridContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/EmotionGridContainer.java
@@ -19,6 +19,11 @@ public class EmotionGridContainer {
     private final List<TextView> textButtonList;
     private final MutableLiveData<Integer> selectedEmotion = new MutableLiveData<>(-1);
 
+    private final Typeface maruburiLight;
+    private final Typeface maruburiBold;
+    private final int colorBlack;
+    private final int colorRed;
+
 
     public EmotionGridContainer(View view) {
         textButtonList = Arrays.asList(
@@ -34,10 +39,12 @@ public class EmotionGridContainer {
             view.findViewById(R.id.angry2Button)
         );
 
-        Typeface maruburiLight = ResourcesCompat.getFont(view.getContext(),
+        maruburiLight = ResourcesCompat.getFont(view.getContext(),
             R.font.maruburi_regular);
-        Typeface maruburiBold = ResourcesCompat.getFont(view.getContext(),
+        maruburiBold = ResourcesCompat.getFont(view.getContext(),
             R.font.maruburi_bold);
+        colorBlack = ContextCompat.getColor(view.getContext(), R.color.black);
+        colorRed = ContextCompat.getColor(view.getContext(), R.color.red);
 
         for (int i = 0; i < textButtonList.size(); i++) {
             TextView textButton = textButtonList.get(i);
@@ -47,14 +54,12 @@ public class EmotionGridContainer {
                 if (previousSelectedEmotion > -1) {
                     TextView previousButton = textButtonList.get(previousSelectedEmotion);
                     previousButton.setTypeface(maruburiLight);
-                    previousButton.setTextColor(ContextCompat.getColor(view.getContext(),
-                        R.color.black));
+                    previousButton.setTextColor(colorBlack);
                 }
 
                 selectedEmotion.setValue(_i);
                 textButton.setTypeface(maruburiBold);
-                textButton.setTextColor(ContextCompat.getColor(view.getContext(),
-                    R.color.red));
+                textButton.setTextColor(colorRed);
 
                 Log.d("EmotionGridContainer",
                     String.format("emotion: %d -> %d", previousSelectedEmotion,
@@ -80,10 +85,19 @@ public class EmotionGridContainer {
         selectedEmotion.observeForever(observer);
     }
 
-    public void freeze() {
+    public void resetUi() {
+        freeze(false);
+        selectedEmotion.setValue(-1);
+        for (TextView textButton : textButtonList) {
+            textButton.setTypeface(maruburiLight);
+            textButton.setTextColor(colorBlack);
+        }
+    }
+
+    public void freeze(boolean freeze) {
         for (int i = 0; i < textButtonList.size(); i++) {
             TextView textButton = textButtonList.get(i);
-            textButton.setClickable(false);
+            textButton.setClickable(!freeze);
         }
     }
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
@@ -132,7 +132,7 @@ public class ListFooterContainer {
             return;
         }
 
-        setHelpTextAfterCompleted(isToday);
+        momentWriterContainer.setInvisible();
 
         freezeStoryEditText();
         storyContainer.setUiWritingStory(storyUiState.getCreatedAt());
@@ -151,6 +151,7 @@ public class ListFooterContainer {
         scoreContainer.setUiVisible();
         scoreContainer.showAutoCompleteWarnText(!storyUiState.isPointCompleted());
 
+        setHelpTextAfterCompleted(isToday);
         state = ListFooterState.SCORE_SELECTING;
     }
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
@@ -127,7 +127,7 @@ public class ListFooterContainer {
         storyContainer.setUiCompleteStory();
 
         emotionGridContainer.selectEmotion(storyUiState.getEmotion());
-        emotionGridContainer.freeze();
+        freezeEmotionSelector();
         emotionWrapper.setVisibility(View.VISIBLE);
 
         tagBoxContainer.setTags(storyUiState.getTags());
@@ -201,7 +201,7 @@ public class ListFooterContainer {
     }
 
     public void freezeEmotionSelector() {
-        emotionGridContainer.freeze();
+        emotionGridContainer.freeze(true);
     }
 
     public void freezeTagEditText() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
@@ -124,7 +124,6 @@ public class ListFooterContainer {
 
             if (isToday) {
                 setUiReadyToAddMoment(false);
-                setBottomButtonState(false);
             } else {
                 momentWriterContainer.setInvisible();
                 state = ListFooterState.INVISIBLE;

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
@@ -123,7 +123,7 @@ public class ListFooterContainer {
 
         storyContainer.setUiWritingStory(storyUiState.getCreatedAt());
         storyContainer.setStoryText(storyUiState.getTitle(), storyUiState.getContent());
-        storyContainer.freeze();
+        freezeStoryEditText();
         storyContainer.setUiCompleteStory();
 
         emotionGridContainer.selectEmotion(storyUiState.getEmotion());
@@ -197,7 +197,7 @@ public class ListFooterContainer {
     }
 
     public void freezeStoryEditText() {
-        storyContainer.freeze();
+        storyContainer.freeze(true);
     }
 
     public void freezeEmotionSelector() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
@@ -106,16 +106,23 @@ public class ListFooterContainer {
     }
 
     public void updateUiWithRemoteData(@NonNull StoryUiState storyUiState, boolean isToday) {
-        momentWriterContainer.setInvisible();
 
-        if (storyUiState.isEmpty()) {
-            // 아직 스토리가 만들어지지 않았을 경우
-            state = ListFooterState.INVISIBLE;
-            return;
-        }
-        if (storyUiState.isEmotionInvalid()) {
-            // 모먼트 없이 자동으로 마무리되어서 감정이 invalid인 경우
-            state = ListFooterState.INVISIBLE;
+        if (storyUiState.isEmpty() || storyUiState.isEmotionInvalid()) {
+            // 보여줄 데이터가 없는 경우
+            storyContainer.resetUi();
+            tagBoxContainer.resetUi();
+            scoreContainer.resetUi();
+
+            emotionGridContainer.resetUi();
+            emotionHelpText.setText(R.string.emotion_help_text);
+            emotionWrapper.setVisibility(View.GONE);
+
+            if (isToday) {
+                setUiReadyToAddMoment();
+            } else {
+                momentWriterContainer.setInvisible();
+                state = ListFooterState.INVISIBLE;
+            }
             return;
         }
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ListFooterContainer.java
@@ -121,17 +121,17 @@ public class ListFooterContainer {
 
         setHelpTextAfterCompleted(isToday);
 
+        freezeStoryEditText();
         storyContainer.setUiWritingStory(storyUiState.getCreatedAt());
         storyContainer.setStoryText(storyUiState.getTitle(), storyUiState.getContent());
-        freezeStoryEditText();
         storyContainer.setUiCompleteStory();
 
-        emotionGridContainer.selectEmotion(storyUiState.getEmotion());
         freezeEmotionSelector();
+        emotionGridContainer.selectEmotion(storyUiState.getEmotion());
         emotionWrapper.setVisibility(View.VISIBLE);
 
+        freezeTagEditText();
         tagBoxContainer.setTags(storyUiState.getTags());
-        tagBoxContainer.freeze();
         tagBoxContainer.setUiVisible();
 
         scoreContainer.setScore(storyUiState.getScore());
@@ -205,7 +205,7 @@ public class ListFooterContainer {
     }
 
     public void freezeTagEditText() {
-        tagBoxContainer.freeze();
+        tagBoxContainer.freeze(true);
     }
 
     public void setUiWritingMoment() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ScoreContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/ScoreContainer.java
@@ -62,9 +62,21 @@ public class ScoreContainer {
         scoreSeekBar.setProgress(score);
     }
 
+    public void resetUi() {
+        freeze(false);
+        scoreWrapper.setVisibility(View.GONE);
+        setScore(DEFAULT_SCORE);
+        scoreHelpText.setText(R.string.score_help_text);
+        showAutoCompleteWarnText(false);
+    }
+
     public void setUiVisible() {
         scoreWrapper.setVisibility(View.VISIBLE);
         scoreWrapper.startAnimation(animationProvider.fadeIn);
+    }
+
+    public void freeze(boolean freeze) {
+        // TODO: 점수 수정 못하도록 freeze
     }
 
     public void setHelpText(String text) {
@@ -79,7 +91,7 @@ public class ScoreContainer {
         }
     }
 
-    public void setSaveScoreSwitch() {
+    private void setSaveScoreSwitch() {
         saveScoreSwitch.setValue(true);
         saveScoreSwitch.setValue(false);
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/StoryContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/StoryContainer.java
@@ -153,7 +153,7 @@ public class StoryContainer {
         return storyContentEditText.getText().toString();
     }
 
-    public void setLimitObserver(Observer<Boolean> observer) {
+    public void observeLimit(Observer<Boolean> observer) {
         isLimitExceeded.observeForever(observer);
     }
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/StoryContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/StoryContainer.java
@@ -153,19 +153,25 @@ public class StoryContainer {
         return storyContentEditText.getText().toString();
     }
 
-    public void freeze() {
-        storyTitleEditText.setEnabled(false);
-        storyTitleEditText.setHint("");
-        storyContentEditText.setEnabled(false);
-        storyContentEditText.setHint("");
-    }
-
     public void setLimitObserver(Observer<Boolean> observer) {
         isLimitExceeded.observeForever(observer);
     }
 
     public void observeAiButtonSwitch(Observer<Boolean> observer) {
         aiButtonSwitch.observeForever(observer);
+    }
+
+    public void resetUi() {
+        storyWrapper.setVisibility(View.GONE);
+
+        setStoryText("", "");
+        freeze(false);
+
+        storyContentLengthText.setVisibility(View.VISIBLE);
+        setStoryContentLengthText(0);
+
+        storyAiButton.setVisibility(View.VISIBLE);
+        aiButtonHelpText.setVisibility(View.VISIBLE);
     }
 
     public void setUiWritingStory(Date completeTime) {
@@ -187,8 +193,16 @@ public class StoryContainer {
         storyAiButton.setVisibility(View.GONE);
     }
 
-    public void setCompleteTimeText(Date completeTime) {
-        completeTimeText.setText(TimeConverter.formatDate(completeTime, "HH:mm"));
+    public void freeze(boolean freeze) {
+        storyTitleEditText.setEnabled(!freeze);
+        storyContentEditText.setEnabled(!freeze);
+        if (freeze) {
+            storyTitleEditText.setHint("");
+            storyContentEditText.setHint("");
+        } else {
+            storyTitleEditText.setHint(R.string.story_title_hint);
+            storyContentEditText.setHint(R.string.story_content_hint);
+        }
     }
 
     public void setStoryText(String title, String content) {
@@ -199,6 +213,10 @@ public class StoryContainer {
     public void setAiButtonVisibility(int visibility) {
         storyAiButton.setVisibility(visibility);
         aiButtonHelpText.setVisibility(visibility);
+    }
+
+    private void setCompleteTimeText(Date completeTime) {
+        completeTimeText.setText(TimeConverter.formatDate(completeTime, "HH:mm"));
     }
 
     private void checkLimitExceeded() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/TagBoxContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/TagBoxContainer.java
@@ -106,7 +106,7 @@ public class TagBoxContainer {
         }
     }
 
-    public void setLimitObserver(Observer<Boolean> observer) {
+    public void observeLimit(Observer<Boolean> observer) {
         isLimitExceeded.observeForever(observer);
     }
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/TagBoxContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/TagBoxContainer.java
@@ -86,13 +86,24 @@ public class TagBoxContainer {
         tagWrapper.startAnimation(animationProvider.fadeIn);
     }
 
+    public void resetUi() {
+        freeze(false);
+        tagEditText.setText("");
+        tagHelpText.setText(R.string.tag_help_text);
+        tagWrapper.setVisibility(View.GONE);
+    }
+
     public void setHelpText(String text) {
         tagHelpText.setText(text);
     }
 
-    public void freeze() {
-        tagEditText.setEnabled(false);
-        tagEditText.setHint("");
+    public void freeze(boolean freeze) {
+        tagEditText.setEnabled(!freeze);
+        if (freeze) {
+            tagEditText.setHint("");
+        } else {
+            tagEditText.setHint(R.string.tag_hint);
+        }
     }
 
     public void setLimitObserver(Observer<Boolean> observer) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -1,11 +1,17 @@
 package snu.swpp.moment.ui.main_writeview.slideview;
 
+import android.content.Intent;
 import android.os.Handler;
 import android.util.Log;
+import android.widget.Toast;
 import androidx.fragment.app.Fragment;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import snu.swpp.moment.LoginRegisterActivity;
 import snu.swpp.moment.MainActivity;
+import snu.swpp.moment.R;
+import snu.swpp.moment.exception.NoInternetException;
+import snu.swpp.moment.exception.UnauthorizedAccessException;
 import snu.swpp.moment.utils.TimeConverter;
 
 public abstract class BaseWritePageFragment extends Fragment {
@@ -65,5 +71,19 @@ public abstract class BaseWritePageFragment extends Fragment {
 
     protected boolean isOutdated() {
         return TimeConverter.hasDayPassed(lastRefreshedTime, getCurrentDateTime());
+    }
+
+    protected void handleApiError(Exception error) {
+        if (error instanceof NoInternetException) {
+            Toast.makeText(requireContext(), R.string.internet_error, Toast.LENGTH_SHORT)
+                .show();
+        } else if (error instanceof UnauthorizedAccessException) {
+            Toast.makeText(requireContext(), R.string.token_expired_error, Toast.LENGTH_SHORT)
+                .show();
+            Intent intent = new Intent(requireContext(), LoginRegisterActivity.class);
+            startActivity(intent);
+        } else {
+            Toast.makeText(requireContext(), R.string.unknown_error, Toast.LENGTH_SHORT).show();
+        }
     }
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -36,14 +36,22 @@ public abstract class BaseWritePageFragment extends Fragment {
     protected abstract void callApisToRefresh();
 
     protected String getDateText() {
-        LocalDate date = getDate();
+        LocalDate date = getCurrentDate();
         String dayOfWeek = date.getDayOfWeek().getDisplayName(
             java.time.format.TextStyle.SHORT, java.util.Locale.KOREAN);
         Log.d("BaseWritePageFragment", "getDateText: date: " + date + ", dayOfWeek: " + dayOfWeek);
         return TimeConverter.formatLocalDate(date, "yyyy. MM. dd.") + " " + dayOfWeek;
     }
 
-    protected abstract LocalDate getDate();
+    /**
+     * 3시 기준으로 보정된 LocalDate
+     */
+    protected abstract LocalDate getCurrentDate();
+
+    /**
+     * API 호출 시 사용할 LocalDateTime
+     */
+    protected abstract LocalDateTime getCurrentDateTime();
 
     protected void updateRefreshTime() {
         lastRefreshedTime = LocalDateTime.now();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -27,7 +27,7 @@ public abstract class BaseWritePageFragment extends Fragment {
         }
     }
 
-    public void setToolbarTitle() {
+    protected void setToolbarTitle() {
         MainActivity mainActivity = (MainActivity) requireActivity();
         mainActivity.setToolbarTitle(getDateText());
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -10,7 +10,7 @@ import snu.swpp.moment.utils.TimeConverter;
 
 public abstract class BaseWritePageFragment extends Fragment {
 
-    protected LocalDateTime lastRefreshedTime = LocalDateTime.now();
+    protected LocalDateTime lastRefreshedTime = getCurrentDateTime();
     private final Handler refreshHandler = new Handler();
     private final long REFRESH_INTERVAL = 1000 * 60 * 5;  // 5 minutes
 
@@ -53,7 +53,7 @@ public abstract class BaseWritePageFragment extends Fragment {
     protected abstract LocalDateTime getCurrentDateTime();
 
     protected void updateRefreshTime() {
-        lastRefreshedTime = LocalDateTime.now();
+        lastRefreshedTime = getCurrentDateTime();
     }
 
     /**

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -3,8 +3,10 @@ package snu.swpp.moment.ui.main_writeview.slideview;
 import android.os.Handler;
 import android.util.Log;
 import androidx.fragment.app.Fragment;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import snu.swpp.moment.MainActivity;
+import snu.swpp.moment.utils.TimeConverter;
 
 public abstract class BaseWritePageFragment extends Fragment {
 
@@ -33,7 +35,15 @@ public abstract class BaseWritePageFragment extends Fragment {
 
     protected abstract void callApisToRefresh();
 
-    protected abstract String getDateText();
+    protected String getDateText() {
+        LocalDate date = getDate();
+        String dayOfWeek = date.getDayOfWeek().getDisplayName(
+            java.time.format.TextStyle.SHORT, java.util.Locale.KOREAN);
+        Log.d("BaseWritePageFragment", "getDateText: date: " + date + ", dayOfWeek: " + dayOfWeek);
+        return TimeConverter.formatLocalDate(date, "yyyy. MM. dd.") + " " + dayOfWeek;
+    }
+
+    protected abstract LocalDate getDate();
 
     protected void updateRefreshTime() {
         lastRefreshedTime = LocalDateTime.now();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/BaseWritePageFragment.java
@@ -13,7 +13,6 @@ public abstract class BaseWritePageFragment extends Fragment {
     protected LocalDateTime lastRefreshedTime = LocalDateTime.now();
     private final Handler refreshHandler = new Handler();
     private final long REFRESH_INTERVAL = 1000 * 60 * 5;  // 5 minutes
-    private final int STARTING_HOUR = 3;
 
     @Override
     public void onResume() {
@@ -65,10 +64,6 @@ public abstract class BaseWritePageFragment extends Fragment {
     }
 
     protected boolean isOutdated() {
-        LocalDateTime now = LocalDateTime.now();
-        if (lastRefreshedTime.getDayOfMonth() == now.getDayOfMonth()) {
-            return false;
-        }
-        return now.getHour() >= STARTING_HOUR;
+        return TimeConverter.hasDayPassed(lastRefreshedTime, getCurrentDateTime());
     }
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -22,8 +22,6 @@ import snu.swpp.moment.data.repository.StoryRepository;
 import snu.swpp.moment.data.source.MomentRemoteDataSource;
 import snu.swpp.moment.data.source.StoryRemoteDataSource;
 import snu.swpp.moment.databinding.PageDailyBinding;
-import snu.swpp.moment.exception.NoInternetException;
-import snu.swpp.moment.exception.UnauthorizedAccessException;
 import snu.swpp.moment.ui.main_writeview.component.ListFooterContainer;
 import snu.swpp.moment.ui.main_writeview.uistate.MomentUiState;
 import snu.swpp.moment.ui.main_writeview.uistate.StoryUiState;
@@ -118,52 +116,35 @@ public class DailyViewFragment extends BaseWritePageFragment {
         // moment GET API 호출 후 동작
         viewModel.observeMomentState((MomentUiState momentUiState) -> {
             Exception error = momentUiState.getError();
-            if (error == null) {
-                listViewItems.clear();
-                if (momentUiState.getNumMoments() > 0) {
-                    binding.noMomentText.setVisibility(View.GONE);
-                    for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
-                        listViewItems.add(new ListViewItem(momentPair));
-                    }
-                } else {
-                    binding.noMomentText.setVisibility(View.VISIBLE);
-                }
-                listViewAdapter.notifyDataSetChanged();
-            } else if (error instanceof NoInternetException) {
-                Toast.makeText(requireContext(), R.string.internet_error, Toast.LENGTH_SHORT)
-                    .show();
-            } else if (error instanceof UnauthorizedAccessException) {
-                Toast.makeText(requireContext(), R.string.token_expired_error,
-                    Toast.LENGTH_SHORT).show();
-                Intent intent = new Intent(requireContext(), LoginRegisterActivity.class);
-                startActivity(intent);
-            } else {
-                Log.d("DailyViewFragment", "Unknown error: " + error.getMessage());
-                Toast.makeText(requireContext(), R.string.unknown_error, Toast.LENGTH_SHORT)
-                    .show();
+            if (error != null) {
+                handleApiError(error);
+                return;
             }
+
+            listViewItems.clear();
+            if (momentUiState.getNumMoments() > 0) {
+                binding.noMomentText.setVisibility(View.GONE);
+                for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
+                    listViewItems.add(new ListViewItem(momentPair));
+                }
+            } else {
+                binding.noMomentText.setVisibility(View.VISIBLE);
+            }
+            listViewAdapter.notifyDataSetChanged();
         });
 
         // story GET API 호출 후 동작
         viewModel.observeStoryState((StoryUiState storyUiState) -> {
             Exception error = storyUiState.getError();
-            if (error == null) {
-                listFooterContainer.updateUiWithRemoteData(storyUiState, false);
-                if (!storyUiState.isEmpty()) {
-                    binding.dailyMomentList.post(() -> binding.dailyMomentList.setSelection(
-                        binding.dailyMomentList.getCount() - 1));
-                }
-            } else if (error instanceof NoInternetException) {
-                Toast.makeText(requireContext(), R.string.internet_error, Toast.LENGTH_SHORT)
-                    .show();
-            } else if (error instanceof UnauthorizedAccessException) {
-                Toast.makeText(requireContext(), R.string.token_expired_error,
-                    Toast.LENGTH_SHORT).show();
-                Intent intent = new Intent(requireContext(), LoginRegisterActivity.class);
-                startActivity(intent);
-            } else {
-                Toast.makeText(requireContext(), R.string.unknown_error, Toast.LENGTH_SHORT)
-                    .show();
+            if (error != null) {
+                handleApiError(error);
+                return;
+            }
+
+            listFooterContainer.updateUiWithRemoteData(storyUiState, false);
+            if (!storyUiState.isEmpty()) {
+                binding.dailyMomentList.post(() -> binding.dailyMomentList.setSelection(
+                    binding.dailyMomentList.getCount() - 1));
             }
         });
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -203,17 +203,19 @@ public class DailyViewFragment extends BaseWritePageFragment {
     @Override
     protected void callApisToRefresh() {
         LocalDateTime currentDateTime = getCurrentDateTime();
+        Log.d("DailyViewFragment", "callApisToRefresh: called with timestamp " + currentDateTime);
         viewModel.getMoment(currentDateTime);
         viewModel.getStory(currentDateTime);
     }
 
     @Override
-    protected LocalDate getDate() {
+    protected LocalDate getCurrentDate() {
         return TimeConverter.getToday().minusDays(minusDays);
     }
 
-    private LocalDateTime getCurrentDateTime() {
-        return getDate().atTime(3, 0, 0);
+    @Override
+    protected LocalDateTime getCurrentDateTime() {
+        return getCurrentDate().atTime(3, 0, 0);
     }
 
     @Override

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -194,7 +194,6 @@ public class DailyViewFragment extends BaseWritePageFragment {
             }
         };
         registerRefreshRunnable(refreshRunnable);
-        updateRefreshTime();
 
         Log.d("DailyViewFragment", "onCreateView() ended");
         return root;

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -107,7 +107,9 @@ public class DailyViewFragment extends BaseWritePageFragment {
             .inflate(R.layout.listview_footer, binding.dailyMomentList, false);
         binding.dailyMomentList.addFooterView(footerView);
 
+        Log.d("DailyViewFragment", "onCreateView: initial API call to refresh");
         callApisToRefresh();
+        updateRefreshTime();
 
         viewModel.observeMomentState((MomentUiState momentUiState) -> {
             Exception error = momentUiState.getError();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -108,7 +108,7 @@ public class DailyViewFragment extends BaseWritePageFragment {
         binding.dailyMomentList.addFooterView(footerView);
 
         // list footer 관리 객체 초기화
-        listFooterContainer = new ListFooterContainer(footerView);
+        listFooterContainer = new ListFooterContainer(footerView, false);
         listFooterContainer.observeSaveScoreSwitch(saveScoreSwitch -> {
             if (saveScoreSwitch) {
                 viewModel.saveScore(listFooterContainer.getScore());

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/DailyViewFragment.java
@@ -208,14 +208,12 @@ public class DailyViewFragment extends BaseWritePageFragment {
     }
 
     @Override
-    protected String getDateText() {
-        LocalDate date = getCurrentDateTime().toLocalDate();
-        return TimeConverter.formatLocalDate(date, "yyyy. MM. dd.");
+    protected LocalDate getDate() {
+        return TimeConverter.getToday().minusDays(minusDays);
     }
 
     private LocalDateTime getCurrentDateTime() {
-        LocalDate date = TimeConverter.getToday().minusDays(minusDays);
-        return date.atTime(3, 0, 0);
+        return getDate().atTime(3, 0, 0);
     }
 
     @Override

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/ListViewAdapter.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/ListViewAdapter.java
@@ -16,7 +16,7 @@ import snu.swpp.moment.utils.AnimationProvider;
 
 public class ListViewAdapter extends BaseAdapter {
 
-    private List<ListViewItem> items;
+    private final List<ListViewItem> items;
     private final Context context;
 
     private int size;

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/ListViewAdapter.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/ListViewAdapter.java
@@ -2,6 +2,7 @@ package snu.swpp.moment.ui.main_writeview.slideview;
 
 import android.content.Context;
 import android.util.Log;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -108,7 +109,7 @@ public class ListViewAdapter extends BaseAdapter {
             // AI 답글 대기중 애니메이션 표시
             textView.setText("· · ·\nAI가 일기를 읽고 있어요");
             textView.setTextAlignment(View.TEXT_ALIGNMENT_CENTER);
-            textView.setAlpha(0.5f);
+            textView.setGravity(Gravity.CENTER);
             textView.clearAnimation();
             textView.startAnimation(animationProvider.fadeInOut);
             Log.d("ListViewAdapter", "showWaitingAnimation() called: activate");
@@ -116,7 +117,7 @@ public class ListViewAdapter extends BaseAdapter {
             // AI 답글 대기중 애니메이션 제거
             textView.setText("");
             textView.setTextAlignment(View.TEXT_ALIGNMENT_TEXT_START);
-            textView.setAlpha(1.0f);
+            textView.setGravity(Gravity.START);
             textView.clearAnimation();
             Log.d("ListViewAdapter", "showWaitingAnimation() called: deactivate");
         }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -292,7 +292,9 @@ public class TodayViewFragment extends BaseWritePageFragment {
             }
         });
 
+        Log.d("TodayViewFragment", "onCreateView: initial API call to refresh");
         callApisToRefresh();
+        updateRefreshTime();
 
         // 날짜 변화 확인해서 GET API 다시 호출
         Runnable refreshRunnable = new Runnable() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -28,8 +28,6 @@ import snu.swpp.moment.data.repository.StoryRepository;
 import snu.swpp.moment.data.source.MomentRemoteDataSource;
 import snu.swpp.moment.data.source.StoryRemoteDataSource;
 import snu.swpp.moment.databinding.PageTodayBinding;
-import snu.swpp.moment.exception.NoInternetException;
-import snu.swpp.moment.exception.UnauthorizedAccessException;
 import snu.swpp.moment.ui.main_writeview.component.BottomButtonContainer;
 import snu.swpp.moment.ui.main_writeview.component.ListFooterContainer;
 import snu.swpp.moment.ui.main_writeview.component.NudgeHeaderContainer;
@@ -233,35 +231,27 @@ public class TodayViewFragment extends BaseWritePageFragment {
         viewModel.observeMomentState(momentUiState -> {
             Exception error = momentUiState.getError();
             Log.d("TodayViewFragment", "Got moment GET response: error=" + error);
+            if (error != null) {
+                handleApiError(error);
+                return;
+            }
 
-            if (error == null) {
-                listViewItems.clear();
-                listViewAdapter.setAnimation(false);
+            listViewItems.clear();
+            listViewAdapter.setAnimation(false);
 
-                if (momentUiState.getNumMoments() > 0) {
-                    bottomButtonContainer.setActivated(true);
-                    for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
-                        listViewItems.add(new ListViewItem(momentPair));
-                    }
-                    listViewAdapter.notifyDataSetChanged();
-                    scrollToBottom();
-                    Log.d("TodayViewFragment", "Got moment GET response: numMoments="
-                        + momentUiState.getNumMoments());
-                } else {
-                    bottomButtonContainer.setActivated(false);
-                    listViewAdapter.notifyDataSetChanged();
-                    Log.d("TodayViewFragment", "Got moment GET response: no moments");
+            if (momentUiState.getNumMoments() > 0) {
+                bottomButtonContainer.setActivated(true);
+                for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
+                    listViewItems.add(new ListViewItem(momentPair));
                 }
-            } else if (error instanceof NoInternetException) {
-                Toast.makeText(requireContext(), R.string.internet_error, Toast.LENGTH_SHORT)
-                    .show();
-            } else if (error instanceof UnauthorizedAccessException) {
-                Toast.makeText(requireContext(), R.string.token_expired_error, Toast.LENGTH_SHORT)
-                    .show();
-                Intent intent = new Intent(requireContext(), LoginRegisterActivity.class);
-                startActivity(intent);
+                listViewAdapter.notifyDataSetChanged();
+                scrollToBottom();
+                Log.d("TodayViewFragment", "Got moment GET response: numMoments="
+                    + momentUiState.getNumMoments());
             } else {
-                Toast.makeText(requireContext(), R.string.unknown_error, Toast.LENGTH_SHORT).show();
+                bottomButtonContainer.setActivated(false);
+                listViewAdapter.notifyDataSetChanged();
+                Log.d("TodayViewFragment", "Got moment GET response: no moments");
             }
         });
 
@@ -270,24 +260,16 @@ public class TodayViewFragment extends BaseWritePageFragment {
             Exception error = savedStoryState.getError();
             Log.d("TodayViewFragment", "Got story GET response: error=" + error + ", isEmpty="
                 + savedStoryState.isEmpty());
+            if (error != null) {
+                handleApiError(error);
+                return;
+            }
 
-            if (error == null) {
-                listFooterContainer.updateUiWithRemoteData(savedStoryState, true);
-                if (!savedStoryState.hasNoData()) {
-                    Log.d("TodayViewFragment",
-                        "Got story GET response: story has valid data");
-                    bottomButtonContainer.setActivated(false, true);
-                }
-            } else if (error instanceof NoInternetException) {
-                Toast.makeText(requireContext(), R.string.internet_error, Toast.LENGTH_SHORT)
-                    .show();
-            } else if (error instanceof UnauthorizedAccessException) {
-                Toast.makeText(requireContext(), R.string.token_expired_error, Toast.LENGTH_SHORT)
-                    .show();
-                Intent intent = new Intent(requireContext(), LoginRegisterActivity.class);
-                startActivity(intent);
-            } else {
-                Toast.makeText(requireContext(), R.string.unknown_error, Toast.LENGTH_SHORT).show();
+            listFooterContainer.updateUiWithRemoteData(savedStoryState, true);
+            if (!savedStoryState.hasNoData()) {
+                Log.d("TodayViewFragment",
+                    "Got story GET response: story has valid data");
+                bottomButtonContainer.setActivated(false, true);
             }
         });
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -298,7 +298,7 @@ public class TodayViewFragment extends BaseWritePageFragment {
         Runnable refreshRunnable = new Runnable() {
             @Override
             public void run() {
-                LocalDateTime now = LocalDateTime.now();
+                LocalDateTime now = getCurrentDateTime();
                 Log.d("TodayViewFragment", "refreshRunnable running at %s" + now);
                 Log.d("TodayViewFragment",
                     "refreshRunnable: current lastRefreshedTime: " + lastRefreshedTime);
@@ -323,14 +323,20 @@ public class TodayViewFragment extends BaseWritePageFragment {
 
     @Override
     protected void callApisToRefresh() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = getCurrentDateTime();
+        Log.d("TodayViewFragment", "callApisToRefresh: called with timestamp " + now);
         viewModel.getMoment(now);
         viewModel.getStory(now);
     }
 
     @Override
-    protected LocalDate getDate() {
+    protected LocalDate getCurrentDate() {
         return TimeConverter.getToday();
+    }
+
+    @Override
+    protected LocalDateTime getCurrentDateTime() {
+        return LocalDateTime.now();
     }
 
     private void scrollToBottom() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -329,11 +329,8 @@ public class TodayViewFragment extends BaseWritePageFragment {
     }
 
     @Override
-    protected String getDateText() {
-        LocalDate today = TimeConverter.getToday();
-        String formatted = TimeConverter.formatLocalDate(today, "yyyy. MM. dd.");
-        Log.d("TodayViewFragment", "getDateText: today=" + today + ", formatted=" + formatted);
-        return formatted;
+    protected LocalDate getDate() {
+        return TimeConverter.getToday();
     }
 
     private void scrollToBottom() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -240,18 +240,25 @@ public class TodayViewFragment extends BaseWritePageFragment {
             listViewAdapter.setAnimation(false);
 
             if (momentUiState.getNumMoments() > 0) {
-                bottomButtonContainer.setActivated(true);
+                Log.d("TodayViewFragment", "Got moment GET response: numMoments="
+                    + momentUiState.getNumMoments());
+
+                StoryUiState savedStoryState = viewModel.getSavedStoryState();
+                if (savedStoryState != null) {
+                    bottomButtonContainer.setActivated(savedStoryState.hasNoData());
+                } else {
+                    bottomButtonContainer.setActivated(true);
+                }
+
                 for (MomentPairModel momentPair : momentUiState.getMomentPairList()) {
                     listViewItems.add(new ListViewItem(momentPair));
                 }
                 listViewAdapter.notifyDataSetChanged();
                 scrollToBottom();
-                Log.d("TodayViewFragment", "Got moment GET response: numMoments="
-                    + momentUiState.getNumMoments());
             } else {
+                Log.d("TodayViewFragment", "Got moment GET response: no moments");
                 bottomButtonContainer.setActivated(false);
                 listViewAdapter.notifyDataSetChanged();
-                Log.d("TodayViewFragment", "Got moment GET response: no moments");
             }
         });
 
@@ -266,7 +273,10 @@ public class TodayViewFragment extends BaseWritePageFragment {
             }
 
             listFooterContainer.updateUiWithRemoteData(savedStoryState, true);
-            if (!savedStoryState.hasNoData()) {
+            if (savedStoryState.hasNoData()) {
+                Log.d("TodayViewFragment", "Got story GET response: story has no data");
+                bottomButtonContainer.setActivated(!listViewItems.isEmpty(), false);
+            } else {
                 Log.d("TodayViewFragment",
                     "Got story GET response: story has valid data");
                 bottomButtonContainer.setActivated(false, true);

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -301,7 +301,7 @@ public class TodayViewFragment extends BaseWritePageFragment {
             @Override
             public void run() {
                 LocalDateTime now = getCurrentDateTime();
-                Log.d("TodayViewFragment", "refreshRunnable running at %s" + now);
+                Log.d("TodayViewFragment", "refreshRunnable running at " + now);
                 Log.d("TodayViewFragment",
                     "refreshRunnable: current lastRefreshedTime: " + lastRefreshedTime);
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/slideview/TodayViewFragment.java
@@ -314,7 +314,6 @@ public class TodayViewFragment extends BaseWritePageFragment {
             }
         };
         registerRefreshRunnable(refreshRunnable);
-        updateRefreshTime();
 
         KeyboardUtils.hideKeyboardOnOutsideTouch(root, requireActivity());
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/uistate/StoryUiState.kt
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/uistate/StoryUiState.kt
@@ -42,5 +42,7 @@ class StoryUiState(
         )
     }
 
+    fun hasNoData() = isEmpty || isEmotionInvalid()
+
     fun isEmotionInvalid() = emotion == EmotionMap.INVALID_EMOTION
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/viewmodel/DailyViewModel.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/viewmodel/DailyViewModel.java
@@ -19,9 +19,10 @@ import snu.swpp.moment.utils.TimeConverter;
 
 public class DailyViewModel extends ViewModel {
 
+    private final MutableLiveData<MomentUiState> momentState = new MutableLiveData<>();
+
     private final GetStoryUseCase getStoryUseCase;
     private final SaveScoreUseCase saveScoreUseCase;
-    private final MutableLiveData<MomentUiState> momentState = new MutableLiveData<>();
     private final AuthenticationRepository authenticationRepository;
     private final MomentRepository momentRepository;
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/viewmodel/GetStoryUseCase.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/viewmodel/GetStoryUseCase.java
@@ -1,6 +1,7 @@
 package snu.swpp.moment.ui.main_writeview.viewmodel;
 
 import android.util.Log;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Observer;
 import java.time.LocalDateTime;
@@ -85,6 +86,10 @@ public class GetStoryUseCase {
                 storyState.setValue(StoryUiState.withError(new UnauthorizedAccessException()));
             }
         });
+    }
+
+    public @Nullable StoryUiState getStoryState() {
+        return storyState.getValue();
     }
 
     public int getStoryId() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/viewmodel/TodayViewModel.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/viewmodel/TodayViewModel.java
@@ -1,6 +1,7 @@
 package snu.swpp.moment.ui.main_writeview.viewmodel;
 
 import android.util.Log;
+import androidx.annotation.Nullable;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModel;
@@ -243,6 +244,10 @@ public class TodayViewModel extends ViewModel {
             return;
         }
         saveScoreUseCase.saveScore(storyId, score);
+    }
+
+    public @Nullable StoryUiState getSavedStoryState() {
+        return getStoryUseCase.getStoryState();
     }
 
     public void observeMomentState(Observer<MomentUiState> observer) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/CalendarUtils.kt
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/CalendarUtils.kt
@@ -57,22 +57,22 @@ fun isFinalWeekOfMonth(day: CalendarDay): Boolean {
 fun fillEmptyStory(storyList: List<CalendarDayState>, month: YearMonth)
         : List<CalendarDayState> {
     val result = mutableListOf<CalendarDayState>()
-    var date = LocalDate.of(month.year, month.month, 1);
-    var index = 0;
+    var date = LocalDate.of(month.year, month.month, 1)
+    var index = 0
     for (i in 0..30) {
         if (index < storyList.size) {
             val story = storyList[index]
             val createdAt = story.date
             if (createdAt.isAfter(date)) {
-                result.add(CalendarDayState.empty());
+                result.add(CalendarDayState.empty())
             } else {
                 result.add(story)
-                index++;
+                index++
             }
         } else {
-            result.add(CalendarDayState.empty());
+            result.add(CalendarDayState.empty())
         }
         date = date.plusDays(1)
     }
-    return result;
+    return result
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/TimeConverter.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/TimeConverter.java
@@ -29,6 +29,14 @@ public class TimeConverter {
         return date;
     }
 
+    public static LocalDate updateDateFromThree(LocalDateTime dateTime) {
+        return updateDateFromThree(dateTime.toLocalDate(), dateTime.getHour());
+    }
+
+    public static boolean hasDayPassed(LocalDateTime base, LocalDateTime cur) {
+        return updateDateFromThree(base).isBefore(updateDateFromThree(cur));
+    }
+
     public static LocalDate getToday() {
         LocalDate today = LocalDate.now();
         int hour = LocalTime.now().getHour();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/TimeConverter.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/TimeConverter.java
@@ -22,25 +22,23 @@ public class TimeConverter {
         return localDateTime.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
     }
 
-    public static LocalDate updateDateFromThree(LocalDate date, int hour) {
+    public static LocalDate adjustToServiceDate(LocalDate date, int hour) {
         if (hour < 3) {
             date = date.minusDays(1);
         }
         return date;
     }
 
-    public static LocalDate updateDateFromThree(LocalDateTime dateTime) {
-        return updateDateFromThree(dateTime.toLocalDate(), dateTime.getHour());
+    public static LocalDate adjustToServiceDate(LocalDateTime dateTime) {
+        return adjustToServiceDate(dateTime.toLocalDate(), dateTime.getHour());
     }
 
     public static boolean hasDayPassed(LocalDateTime base, LocalDateTime cur) {
-        return updateDateFromThree(base).isBefore(updateDateFromThree(cur));
+        return adjustToServiceDate(base).isBefore(adjustToServiceDate(cur));
     }
 
     public static LocalDate getToday() {
-        LocalDate today = LocalDate.now();
-        int hour = LocalTime.now().getHour();
-        return updateDateFromThree(today, hour);
+        return adjustToServiceDate(LocalDateTime.now());
     }
 
     public static String formatLocalDate(LocalDate date, String formatString) {

--- a/frontend/Moment/app/src/test/java/snu/swpp/moment/ui/login/LoginViewModelTest.java
+++ b/frontend/Moment/app/src/test/java/snu/swpp/moment/ui/login/LoginViewModelTest.java
@@ -77,7 +77,7 @@ public class LoginViewModelTest extends TestCase {
         // Then
         LiveData<LoginResultState> loginResultState = loginViewModel.getLoginResult();
 
-        assertEquals(loginResultState.getValue().getSuccess().getDisplayName(), "test_nickname");
+        assertEquals(loginResultState.getValue().getSuccess().getNickname(), "test_nickname");
     }
 
     @Test

--- a/frontend/Moment/app/src/test/java/snu/swpp/moment/ui/register/RegisterViewModelTest.java
+++ b/frontend/Moment/app/src/test/java/snu/swpp/moment/ui/register/RegisterViewModelTest.java
@@ -74,7 +74,7 @@ public class RegisterViewModelTest extends TestCase {
         // Then
         LiveData<RegisterResultState> registerResultState = registerViewModel.getRegisterResult();
 
-        assertEquals(registerResultState.getValue().getSuccess().getDisplayName(), "test_nickname");
+        assertEquals(registerResultState.getValue().getSuccess().getNickname(), "test_nickname");
     }
 
     @Test

--- a/frontend/Moment/app/src/test/java/snu/swpp/moment/utils/TimeConverterTest.java
+++ b/frontend/Moment/app/src/test/java/snu/swpp/moment/utils/TimeConverterTest.java
@@ -2,14 +2,11 @@ package snu.swpp.moment.utils;
 
 import static org.junit.Assert.*;
 
-import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,19 +45,19 @@ public class TimeConverterTest {
     }
 
     @Test
-    public void updateDateFromThree_before3() {
+    public void adjustToServiceDate_before3() {
         LocalDate date = LocalDate.of(2023, 11, 3);
         int hour = 2;
-        LocalDate convertedDate = TimeConverter.updateDateFromThree(date, hour);
+        LocalDate convertedDate = TimeConverter.adjustToServiceDate(date, hour);
         LocalDate answer = LocalDate.of(2023, 11, 2);
         assertTrue(convertedDate.isEqual(answer));
     }
 
     @Test
-    public void updateDateFromThree_after3() {
+    public void adjustToServiceDate_after3() {
         LocalDate date = LocalDate.of(2023, 11, 3);
         int hour = 12;
-        LocalDate convertedDate = TimeConverter.updateDateFromThree(date, hour);
+        LocalDate convertedDate = TimeConverter.adjustToServiceDate(date, hour);
         LocalDate answer = LocalDate.of(2023, 11, 3);
         assertTrue(convertedDate.isEqual(answer));
     }

--- a/frontend/Moment/app/src/test/java/snu/swpp/moment/utils/TimeConverterTest.java
+++ b/frontend/Moment/app/src/test/java/snu/swpp/moment/utils/TimeConverterTest.java
@@ -142,4 +142,26 @@ public class TimeConverterTest {
         System.out.println("convertedLocalDate: " + convertedLocalDate.toString());
         assertTrue(answer.isEqual(convertedLocalDate));
     }
+
+    @Test
+    public void hasDayPassed() {
+        LocalDateTime base, cur;
+
+        base = LocalDateTime.of(2023, 11, 3, 8, 0, 0);
+        cur = LocalDateTime.of(2023, 11, 3, 21, 0, 0);
+        assertFalse(TimeConverter.hasDayPassed(base, cur));
+
+        cur = LocalDateTime.of(2023, 11, 4, 2, 0, 0);
+        assertFalse(TimeConverter.hasDayPassed(base, cur));
+
+        cur = LocalDateTime.of(2023, 11, 4, 3, 0, 0);
+        assertTrue(TimeConverter.hasDayPassed(base, cur));
+
+        base = LocalDateTime.of(2023, 11, 3, 1, 0, 0);
+        cur = LocalDateTime.of(2023, 11, 3, 2, 0, 0);
+        assertFalse(TimeConverter.hasDayPassed(base, cur));
+
+        cur = LocalDateTime.of(2023, 11, 3, 3, 0, 0);
+        assertTrue(TimeConverter.hasDayPassed(base, cur));
+    }
 }


### PR DESCRIPTION
### Frontend/A6: 쓰기탭 자동 새로고침 오류 해결

#### PR Description: 
* 새로고침을 해야 하는지 여부를 판정하는 `isOutdated()`의 로직에 오류가 있어서 고쳤습니다.
  - `TimeConverter`에 새로운 함수를 추가했고, unit test도 완료했습니다.
* `DailyViewFragment`에서 `lastFreshedTime`을 잘못 초기화하고 있어서 고쳤습니다.
* 테스트 하다가 `getNickname()` 관련 오류를 발견해서 고쳤습니다.

#### Additional Comments: 
한 번 더 밤새 테스트 해봐야 할 것 같습니다.
