### PR TITLE
Backend/A7: Implement spreading of Korean hashtags

### DIFF
--- a/backend/config/requirements.txt
+++ b/backend/config/requirements.txt
@@ -8,3 +8,4 @@ tzdata==2023.3
 openai==0.28.1
 freezegun==1.2.2
 django-crontab==0.7.1
+jamo==0.4.1

--- a/backend/moment/writing/search_views.py
+++ b/backend/moment/writing/search_views.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from .models import Story
 from .search_serializers import HashtagCompleteSerializer
 from .utils.log import print_log
+from .utils.search import spread_korean
 
 
 class HashtagCompleteView(GenericAPIView):
@@ -16,13 +17,13 @@ class HashtagCompleteView(GenericAPIView):
         params = HashtagCompleteSerializer(data=request.query_params)
         params.is_valid(raise_exception=True)
 
-        tag_query = params.validated_data["tag_query"]
+        tag_query = spread_korean(params.validated_data["tag_query"])
 
         stories = Story.objects.filter(user_id=request.user.id)
         tag_set = set()
         for story in stories:
             for tag in story.hashtags.all():
-                if tag_query not in tag.content:
+                if tag_query not in spread_korean(tag.content):
                     continue
                 tag_set.add(tag.content)
 

--- a/backend/moment/writing/tests/search_tests.py
+++ b/backend/moment/writing/tests/search_tests.py
@@ -13,9 +13,11 @@ class HashtagCompleteTest(TestCase):
     def setUp(self):
         user1 = User.objects.create(username="test1")
         user2 = User.objects.create(username="test2")
+
         hashtag_1_1 = Hashtag.objects.create(content="우왕")
         hashtag_1_2 = Hashtag.objects.create(content="우와아아")
         hashtag_1_3 = Hashtag.objects.create(content="우아아")
+
         hashtag_2_1 = Hashtag.objects.create(content="우아아아")
 
         story1 = Story.objects.create(
@@ -40,6 +42,19 @@ class HashtagCompleteTest(TestCase):
         user = User.objects.get(username="test1")
         view = HashtagCompleteView.as_view()
         params = {"tag_query": "아아"}
+
+        request = factory.get("writing/hashtags/complete/", params)
+        force_authenticate(request, user=user)
+        response = view(request)
+        self.assertEqual(len(response.data["hashtags"]), 2)
+        self.assertEqual(response.data["hashtags"][0], "우아아")
+        self.assertEqual(response.data["hashtags"][1], "우와아아")
+
+    def test_hashtag_completion_korean_spread(self):
+        factory = APIRequestFactory()
+        user = User.objects.get(username="test1")
+        view = HashtagCompleteView.as_view()
+        params = {"tag_query": "아ㅇ"}
 
         request = factory.get("writing/hashtags/complete/", params)
         force_authenticate(request, user=user)

--- a/backend/moment/writing/utils/search.py
+++ b/backend/moment/writing/utils/search.py
@@ -1,0 +1,5 @@
+from jamo import h2j, j2hcj
+
+
+def spread_korean(string: str) -> str:
+    return j2hcj(h2j(string))


### PR DESCRIPTION
### Backend/A7: Implement spreading of Korean hashtags

#### PR Description: 
* 문자열 비교 시에 한글 펼쳐쓰기를 적용하는 부분을 추가했습니다. 예를 들어 `태ㄱ`라고만 입력해도 `태그`를 검색할 수 있습니다.

#### Additional Comments: 
None
