### PR TITLE
backend/cron-fix: Give invalid emotion and score for auto completion

### DIFF
--- a/backend/moment/writing/cron.py
+++ b/backend/moment/writing/cron.py
@@ -47,6 +47,7 @@ def auto_completion_job():
                     minute=59,
                     second=59,
                 ),
+                score=0,
             )
             story.save()
         else:
@@ -69,6 +70,8 @@ def auto_completion_job():
                     minute=59,
                     second=59,
                 ),
+                score=0,
+                emotion=Emotions.INVALID,
             )
             story.save()
 

--- a/backend/moment/writing/tests/tests.py
+++ b/backend/moment/writing/tests/tests.py
@@ -273,6 +273,7 @@ class AutoCompletionTest(TestCase):
         auto_completion_job()
         created_story = Story.objects.get(user=self.test_user)
         self.assertEqual(created_story.emotion, Emotions.INVALID)
+        self.assertEqual(created_story.score, 0)
         self.assertEqual(
             created_story.created_at.timestamp(),
             (datetime.datetime.now() - datetime.timedelta(seconds=2)).timestamp(),
@@ -318,7 +319,8 @@ class AutoCompletionTest(TestCase):
 
         auto_completion_job()
         created_story = Story.objects.get(user=self.test_user)
-        self.assertEqual(created_story.emotion, Emotions.NORMAL1)
+        self.assertEqual(created_story.emotion, Emotions.INVALID)
+        self.assertEqual(created_story.score, 0)
         self.assertEqual(created_story.title, ai_sample_title)
         self.assertEqual(created_story.content, ai_sample_story)
         mock_add.assert_any_call(
@@ -364,7 +366,8 @@ class AutoCompletionTest(TestCase):
 
         auto_completion_job()
         created_story = Story.objects.get(user=self.test_user)
-        self.assertEqual(created_story.emotion, Emotions.NORMAL1)
+        self.assertEqual(created_story.emotion, Emotions.INVALID)
+        self.assertEqual(created_story.score, 0)
         self.assertEqual(created_story.title, GPT_AUTOCOMPLETION_ERROR_TITLE)
         self.assertEqual(created_story.content, GPT_AUTOCOMPLETION_ERROR_CONTENT)
         mock_add.assert_any_call(


### PR DESCRIPTION
### PR Title: 자동 마무리 수정

#### PR Description: 
자동 마무리시 감정 및 점수 Invalid,0으로 주도록 수정했습니다.
#### Additional Comments: 
None