### PR TITLE
Hotfix: Remove trailing space in parsed tags

### DIFF
--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/TagBoxContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/component/TagBoxContainer.java
@@ -82,7 +82,7 @@ public class TagBoxContainer {
                     // 사용자 입력이 시작되면 맨 앞에 # 추가
                     s.insert(0, "#");
                 }
-                Log.d("TagBoxContainer", "afterTextChanged: " + s);
+                Log.d("TagBoxContainer", "afterTextChanged - changed to: " + s);
                 List<String> currentTags = parseTags(s.toString());
                 if (currentTags.size() > MAX_TAGS) {
                     // 개수 제한 초과
@@ -156,7 +156,11 @@ public class TagBoxContainer {
         for (String tag : tags) {
             sb.append("#").append(tag).append(" ");
         }
-        tagEditText.setText(sb.toString());
+        Log.d("TagBoxContainer", "setTags: " + tags + ", parsed to " + sb);
+        if (sb.length() > 0) {
+            // 마지막 공백은 제거
+            tagEditText.setText(sb.substring(0, sb.length() - 1));
+        }
     }
 
     public void setHelpText(String text) {


### PR DESCRIPTION
### Hotfix: Remove trailing space in parsed tags

#### PR Description: 
서버에서 받아온 `List<String>` 형식의 태그들을 문자열로 parse 하는 과정에서 맨 끝에 공백이 하나 붙는데, 이걸 스페이스바를 누른 것으로 인식해 `#`을 하나 더 붙여주고 있어서 맨 끝의 공백을 지우도록 조치했습니다.