### PR TITLE
Iter5 P11: 프론트 - 유저 정보 탭 API & local data 연결

### DIFF
--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/api/ServiceApi.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/api/ServiceApi.java
@@ -51,7 +51,8 @@ public interface ServiceApi {
     Call<RegisterResponse> userRegister(@Body RegisterRequest data);
 
     @PUT("/api/user/info")
-    Call<NicknameUpdateResponse> updateNickname(@Body NicknameUpdateRequest data);
+    Call<NicknameUpdateResponse> updateNickname(@Header("Authorization") String bearerToken,
+        @Body NicknameUpdateRequest data);
 
     @GET("api/writing/moments/")
     Call<MomentGetResponse> getMoments(@Header("Authorization") String bearerToken,

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/api/ServiceApi.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/api/ServiceApi.java
@@ -5,11 +5,13 @@ import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.POST;
+import retrofit2.http.PUT;
 import retrofit2.http.Query;
 import snu.swpp.moment.api.request.EmotionSaveRequest;
 import snu.swpp.moment.api.request.HashtagSaveRequest;
 import snu.swpp.moment.api.request.LoginRequest;
 import snu.swpp.moment.api.request.MomentWriteRequest;
+import snu.swpp.moment.api.request.NicknameUpdateRequest;
 import snu.swpp.moment.api.request.RegisterRequest;
 import snu.swpp.moment.api.request.ScoreSaveRequest;
 import snu.swpp.moment.api.request.StoryCompletionNotifyRequest;
@@ -22,6 +24,7 @@ import snu.swpp.moment.api.response.HashtagSaveResponse;
 import snu.swpp.moment.api.response.LoginResponse;
 import snu.swpp.moment.api.response.MomentGetResponse;
 import snu.swpp.moment.api.response.MomentWriteResponse;
+import snu.swpp.moment.api.response.NicknameUpdateResponse;
 import snu.swpp.moment.api.response.RegisterResponse;
 import snu.swpp.moment.api.response.ScoreSaveResponse;
 import snu.swpp.moment.api.response.SearchContentsResponse;
@@ -46,6 +49,9 @@ public interface ServiceApi {
 
     @POST("api/user/register")
     Call<RegisterResponse> userRegister(@Body RegisterRequest data);
+
+    @PUT("/api/user/info")
+    Call<NicknameUpdateResponse> updateNickname(@Body NicknameUpdateRequest data);
 
     @GET("api/writing/moments/")
     Call<MomentGetResponse> getMoments(@Header("Authorization") String bearerToken,
@@ -95,5 +101,4 @@ public interface ServiceApi {
     @GET("/api/writing/search/hashtags/")
     Call<SearchHashtagsResponse> getHashtagSearchList(@Header("Authorization") String bearerToken,
         @Query("query") String query);
-
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/api/request/NicknameUpdateRequest.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/api/request/NicknameUpdateRequest.java
@@ -1,0 +1,14 @@
+package snu.swpp.moment.api.request;
+
+import com.google.gson.annotations.SerializedName;
+
+public class NicknameUpdateRequest {
+
+    @SerializedName("nickname")
+    private final String nickname;
+
+    public NicknameUpdateRequest(String nickname) {
+        this.nickname = nickname;
+    }
+
+}

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/api/response/NicknameUpdateResponse.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/api/response/NicknameUpdateResponse.java
@@ -1,0 +1,13 @@
+package snu.swpp.moment.api.response;
+
+import com.google.gson.annotations.SerializedName;
+
+public class NicknameUpdateResponse {
+
+    @SerializedName("nickname")
+    private String nickname;
+
+    public String getNickname() {
+        return nickname;
+    }
+}

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/callback/NicknameCallBack.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/callback/NicknameCallBack.java
@@ -2,5 +2,5 @@ package snu.swpp.moment.data.callback;
 
 public interface NicknameCallBack {
     void onSuccess(String nickname);
-    void onFailure(Exception exception);
+    void onFailure(Exception error);
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/callback/NicknameCallBack.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/callback/NicknameCallBack.java
@@ -1,0 +1,6 @@
+package snu.swpp.moment.data.callback;
+
+public interface NicknameCallBack {
+    void onSuccess(String nickname);
+    void onFailure(Exception exception);
+}

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/model/LoggedInUserModel.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/model/LoggedInUserModel.java
@@ -3,6 +3,7 @@ package snu.swpp.moment.data.model;
 import java.time.LocalDateTime;
 import snu.swpp.moment.api.response.LoginResponse;
 import snu.swpp.moment.api.response.RegisterResponse;
+import snu.swpp.moment.utils.TimeConverter;
 
 /**
  * Data class that captures user information for logged in users retrieved from LoginRepository
@@ -26,7 +27,7 @@ public class LoggedInUserModel {
     public LoggedInUserModel(LoginResponse.User user, LoginResponse.Token token) {
         this.username = user.getUsername();
         this.nickName = user.getNickname();
-        this.createAt = user.getCreatedAt();
+        this.createAt = TimeConverter.convertUTCToLocalTimeZone(user.getCreatedAt().substring(0, 19));
         this.AccessToken = token.getAccessToken();
         this.RefreshToken = token.getRefreshToken();
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/repository/AuthenticationRepository.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/repository/AuthenticationRepository.java
@@ -148,8 +148,7 @@ public class AuthenticationRepository extends BaseRepository<UserRemoteDataSourc
     }
 
 
-    public void updateNickname(String nickname, NicknameCallBack callback) {
-        String access_token = localDataSource.getToken().getAccessToken();
+    public void updateNickname(String access_token, String nickname, NicknameCallBack callback) {
         remoteDataSource.updateNickname(access_token, nickname, new NicknameCallBack() {
             @Override
             public void onSuccess(String nickname) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/repository/AuthenticationRepository.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/repository/AuthenticationRepository.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import androidx.test.espresso.IdlingResource;
 import androidx.test.espresso.idling.CountingIdlingResource;
 import snu.swpp.moment.data.callback.AuthenticationCallBack;
+import snu.swpp.moment.data.callback.NicknameCallBack;
 import snu.swpp.moment.data.callback.RefreshCallBack;
 import snu.swpp.moment.data.callback.TokenCallBack;
 import snu.swpp.moment.data.model.LoggedInUserModel;
@@ -137,6 +138,23 @@ public class AuthenticationRepository extends BaseRepository<UserRemoteDataSourc
             @Override
             public void onFailure(String errorMessage) {
                 registerCallBack.onFailure(errorMessage);
+            }
+        });
+    }
+
+
+    public void updateNickname(String nickname, NicknameCallBack callback) {
+        String access_token = localDataSource.getToken().getAccessToken();
+        remoteDataSource.updateNickname(access_token, nickname, new NicknameCallBack() {
+            @Override
+            public void onSuccess(String nickname) {
+                localDataSource.saveNickname(nickname);
+                callback.onSuccess(nickname);
+            }
+
+            @Override
+            public void onFailure(Exception error) {
+                callback.onFailure(error);
             }
         });
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/repository/AuthenticationRepository.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/repository/AuthenticationRepository.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.Log;
 import androidx.test.espresso.IdlingResource;
 import androidx.test.espresso.idling.CountingIdlingResource;
+import java.time.LocalDate;
 import snu.swpp.moment.data.callback.AuthenticationCallBack;
 import snu.swpp.moment.data.callback.NicknameCallBack;
 import snu.swpp.moment.data.callback.RefreshCallBack;
@@ -142,6 +143,10 @@ public class AuthenticationRepository extends BaseRepository<UserRemoteDataSourc
         });
     }
 
+    public String getNickname() {
+        return localDataSource.getNickname();
+    }
+
 
     public void updateNickname(String nickname, NicknameCallBack callback) {
         String access_token = localDataSource.getToken().getAccessToken();
@@ -163,7 +168,7 @@ public class AuthenticationRepository extends BaseRepository<UserRemoteDataSourc
         return localDataSource.getToken();
     }
 
-    public String getCreatedAt() {
+    public LocalDate getCreatedAt() {
         return localDataSource.getCreatedAt();
     }
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
@@ -42,6 +42,10 @@ public class UserLocalDataSource {
         // username은 오는데 저장은 따로 아직 안했음 (굳이?)
     }
 
+    public String getNickname() {
+        return sharedPreferences.getString("nickname", DEFAULT_STRING);
+    }
+
     public void saveToken(String token) {
         editor.putString("access_token", token);
         editor.apply();

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
@@ -71,7 +71,8 @@ public class UserLocalDataSource {
     }
 
     public LocalDate getCreatedAt() {
-        String dateTimeInString = sharedPreferences.getString("created_at", DEFAULT_STRING);
+        String dateTimeInString = sharedPreferences.getString("created_at", DEFAULT_STRING)
+            .substring(0, 19); // 초 단위까지만 parsing;
         if (dateTimeInString.isBlank()) {
             return TimeConverter.getToday();
         }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
@@ -7,8 +7,11 @@ import androidx.security.crypto.EncryptedSharedPreferences;
 import androidx.security.crypto.MasterKeys;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import snu.swpp.moment.data.model.LoggedInUserModel;
 import snu.swpp.moment.data.model.TokenModel;
+import snu.swpp.moment.utils.TimeConverter;
 
 public class UserLocalDataSource {
 
@@ -67,8 +70,13 @@ public class UserLocalDataSource {
             "refresh_token");
     }
 
-    public String getCreatedAt() {
-        return sharedPreferences.getString("created_at", DEFAULT_STRING);
+    // TODO
+    public LocalDate getCreatedAt() {
+        String dateTimeInString = sharedPreferences.getString("created_at", DEFAULT_STRING);
+        if (dateTimeInString.isBlank()) {
+            return TimeConverter.getToday();
+        }
+        return TimeConverter.adjustToServiceDate(LocalDateTime.parse(dateTimeInString));
     }
 
     public void logout() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
@@ -42,6 +42,11 @@ public class UserLocalDataSource {
         // username은 오는데 저장은 따로 아직 안했음 (굳이?)
     }
 
+    public void saveNickname(String nickname) {
+        editor.putString("nickname", nickname);
+        editor.apply();
+    }
+
     public String getNickname() {
         return sharedPreferences.getString("nickname", DEFAULT_STRING);
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserLocalDataSource.java
@@ -70,7 +70,6 @@ public class UserLocalDataSource {
             "refresh_token");
     }
 
-    // TODO
     public LocalDate getCreatedAt() {
         String dateTimeInString = sharedPreferences.getString("created_at", DEFAULT_STRING);
         if (dateTimeInString.isBlank()) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserRemoteDataSource.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserRemoteDataSource.java
@@ -6,17 +6,23 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 import snu.swpp.moment.api.request.LoginRequest;
+import snu.swpp.moment.api.request.NicknameUpdateRequest;
 import snu.swpp.moment.api.request.RegisterRequest;
 import snu.swpp.moment.api.request.TokenRefreshRequest;
 import snu.swpp.moment.api.request.TokenVerifyRequest;
 import snu.swpp.moment.api.response.LoginResponse;
+import snu.swpp.moment.api.response.NicknameUpdateResponse;
 import snu.swpp.moment.api.response.RegisterResponse;
 import snu.swpp.moment.api.response.TokenRefreshResponse;
 import snu.swpp.moment.api.response.TokenVerifyResponse;
 import snu.swpp.moment.data.callback.AuthenticationCallBack;
+import snu.swpp.moment.data.callback.NicknameCallBack;
 import snu.swpp.moment.data.callback.RefreshCallBack;
 import snu.swpp.moment.data.callback.TokenCallBack;
 import snu.swpp.moment.data.model.LoggedInUserModel;
+import snu.swpp.moment.exception.NoInternetException;
+import snu.swpp.moment.exception.UnauthorizedAccessException;
+import snu.swpp.moment.exception.UnknownErrorException;
 
 /**
  * Class that handles authentication w/ login credentials and retrieves user information.
@@ -127,6 +133,29 @@ public class UserRemoteDataSource extends BaseRemoteDataSource {
 
             @Override
             public void onFailure(Call<TokenRefreshResponse> call, Throwable t) {
+            }
+        });
+    }
+
+    public void updateNickname(String token, String nickname, NicknameCallBack callBack) {
+        NicknameUpdateRequest request = new NicknameUpdateRequest(nickname);
+        service.updateNickname(request).enqueue(new Callback<>() {
+            @Override
+            public void onResponse(Call<NicknameUpdateResponse> call,
+                Response<NicknameUpdateResponse> response) {
+                Log.d("APICall", "nickname: " + response.code());
+                if (response.isSuccessful()) {
+                    callBack.onSuccess(response.body().getNickname());
+                } else if (response.code() == 401) {
+                    callBack.onFailure(new UnauthorizedAccessException());
+                } else {
+                    callBack.onFailure(new UnknownErrorException());
+                }
+            }
+
+            @Override
+            public void onFailure(Call<NicknameUpdateResponse> call, Throwable t) {
+                callBack.onFailure(new NoInternetException());
             }
         });
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserRemoteDataSource.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/data/source/UserRemoteDataSource.java
@@ -137,9 +137,10 @@ public class UserRemoteDataSource extends BaseRemoteDataSource {
         });
     }
 
-    public void updateNickname(String token, String nickname, NicknameCallBack callBack) {
+    public void updateNickname(String access_token, String nickname, NicknameCallBack callBack) {
+        String bearer = "Bearer " + access_token;
         NicknameUpdateRequest request = new NicknameUpdateRequest(nickname);
-        service.updateNickname(request).enqueue(new Callback<>() {
+        service.updateNickname(bearer, request).enqueue(new Callback<>() {
             @Override
             public void onResponse(Call<NicknameUpdateResponse> call,
                 Response<NicknameUpdateResponse> response) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/NicknameUpdateErrorState.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/NicknameUpdateErrorState.java
@@ -1,0 +1,14 @@
+package snu.swpp.moment.ui.main_userinfoview;
+
+public class NicknameUpdateErrorState {
+
+    private final Exception error;
+
+    public NicknameUpdateErrorState(Exception error) {
+        this.error = error;
+    }
+
+    public Exception getError() {
+        return error;
+    }
+}

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
@@ -59,10 +59,7 @@ public class UserInfoViewFragment extends Fragment {
                 if (errorState.getError() instanceof UnauthorizedAccessException) {
                     startActivity(new Intent(requireActivity(), LoginActivity.class));
                 }
-            } else if (userInfoWrapperContainer.isIconClicked())  {
-                Toast.makeText(requireContext(), R.string.nickname_update_success, Toast.LENGTH_SHORT).show();
             }
-            userInfoWrapperContainer.setIconClicked(true);
         });
 
         // 수정 아이콘

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
@@ -17,6 +17,8 @@ import snu.swpp.moment.R;
 import snu.swpp.moment.data.factory.AuthenticationRepositoryFactory;
 import snu.swpp.moment.data.repository.AuthenticationRepository;
 import snu.swpp.moment.databinding.FragmentUserinfoviewBinding;
+import snu.swpp.moment.exception.UnauthorizedAccessException;
+import snu.swpp.moment.ui.login.LoginActivity;
 import snu.swpp.moment.utils.TimeConverter;
 
 public class UserInfoViewFragment extends Fragment {
@@ -54,6 +56,9 @@ public class UserInfoViewFragment extends Fragment {
             if (errorState.getError() != null) {
                 String message = errorState.getError().getMessage();
                 Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
+                if (errorState.getError() instanceof UnauthorizedAccessException) {
+                    startActivity(new Intent(requireActivity(), LoginActivity.class));
+                }
             } else if (userInfoWrapperContainer.isIconClicked())  {
                 Toast.makeText(requireContext(), R.string.nickname_update_success, Toast.LENGTH_SHORT).show();
             }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
@@ -50,12 +50,16 @@ public class UserInfoViewFragment extends Fragment {
         userInfoWrapperContainer.setCreatedAtText(daysPassedSinceRegistration);
 
         viewModel.getNicknameUpdateErrorState().observe(getViewLifecycleOwner(), errorState -> {
-            if (errorState.getError() == null)  {
+            if (errorState.getError() != null) {
+                String message = errorState.getError().getMessage();
+                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
+            } else if (userInfoWrapperContainer.isIconClicked())  {
                 Toast.makeText(requireContext(), R.string.nickname_update_success, Toast.LENGTH_SHORT).show();
             } else {
                 String message = errorState.getError().getMessage();
                 Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
             }
+            userInfoWrapperContainer.setIconClicked(true);
         });
 
         // 수정 아이콘

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
@@ -3,6 +3,7 @@ package snu.swpp.moment.ui.main_userinfoview;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -36,7 +37,7 @@ public class UserInfoViewFragment extends Fragment {
 
     public View onCreateView(@NonNull LayoutInflater inflater,
         ViewGroup container, Bundle savedInstanceState) {
-
+        Log.d("UserInfoViewFragment", "created");
         binding = FragmentUserinfoviewBinding.inflate(inflater, container, false);
 
         userInfoWrapperContainer = new UserInfoWrapperContainer(binding.userInfoWrapper);
@@ -45,8 +46,8 @@ public class UserInfoViewFragment extends Fragment {
 
         binding.logoutButton.setActivated(true);
 
-        long daysPassedSinceRegistration = viewModel.getCreatedAt()
-            .until(TimeConverter.getToday(), ChronoUnit.HOURS) + 1;
+        int daysPassedSinceRegistration = (int) ChronoUnit.DAYS.between(
+            viewModel.getCreatedAt(), TimeConverter.getToday());
         userInfoWrapperContainer.setCreatedAtText(daysPassedSinceRegistration);
 
         viewModel.getNicknameUpdateErrorState().observe(getViewLifecycleOwner(), errorState -> {
@@ -55,9 +56,6 @@ public class UserInfoViewFragment extends Fragment {
                 Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
             } else if (userInfoWrapperContainer.isIconClicked())  {
                 Toast.makeText(requireContext(), R.string.nickname_update_success, Toast.LENGTH_SHORT).show();
-            } else {
-                String message = errorState.getError().getMessage();
-                Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
             }
             userInfoWrapperContainer.setIconClicked(true);
         });

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewFragment.java
@@ -50,7 +50,9 @@ public class UserInfoViewFragment extends Fragment {
         userInfoWrapperContainer.setCreatedAtText(daysPassedSinceRegistration);
 
         viewModel.getNicknameUpdateErrorState().observe(getViewLifecycleOwner(), errorState -> {
-            if (errorState != null) {
+            if (errorState.getError() == null)  {
+                Toast.makeText(requireContext(), R.string.nickname_update_success, Toast.LENGTH_SHORT).show();
+            } else {
                 String message = errorState.getError().getMessage();
                 Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show();
             }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModel.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModel.java
@@ -30,7 +30,7 @@ public class UserInfoViewModel extends ViewModel {
         return nickname;
     }
 
-    public void setNickname(String nickname) {
+    private void setNickname(String nickname) {
         this.nickname = nickname;
     }
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModel.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModel.java
@@ -1,16 +1,27 @@
 package snu.swpp.moment.ui.main_userinfoview;
 
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
+import java.time.LocalDate;
+import snu.swpp.moment.data.callback.NicknameCallBack;
 import snu.swpp.moment.data.repository.AuthenticationRepository;
 
 public class UserInfoViewModel extends ViewModel {
 
     private String nickname;
     private final AuthenticationRepository repository;
+    private final MutableLiveData<NicknameUpdateErrorState> nicknameUpdateErrorState;
 
     public UserInfoViewModel(AuthenticationRepository repository) {
         this.repository = repository;
-        this.nickname = "닉네임";
+        this.nickname = repository.getNickname();
+        this.nicknameUpdateErrorState = new MutableLiveData<>();
+        nicknameUpdateErrorState.setValue(new NicknameUpdateErrorState(null));
+    }
+
+    public LiveData<NicknameUpdateErrorState> getNicknameUpdateErrorState() {
+        return nicknameUpdateErrorState;
     }
 
     public String getNickname() {
@@ -19,6 +30,24 @@ public class UserInfoViewModel extends ViewModel {
 
     public void setNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateNickname(String nickname) {
+        repository.updateNickname(nickname, new NicknameCallBack() {
+            @Override
+            public void onSuccess(String nickname) {
+                setNickname(nickname);
+            }
+
+            @Override
+            public void onFailure(Exception error) {
+                nicknameUpdateErrorState.setValue(new NicknameUpdateErrorState(error));
+            }
+        });
+    }
+
+    public LocalDate getCreatedAt() {
+        return repository.getCreatedAt();
     }
 
     public void logout() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModel.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModel.java
@@ -37,6 +37,7 @@ public class UserInfoViewModel extends ViewModel {
             @Override
             public void onSuccess(String nickname) {
                 setNickname(nickname);
+                nicknameUpdateErrorState.setValue(new NicknameUpdateErrorState(null));
             }
 
             @Override

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
@@ -19,14 +19,12 @@ public class UserInfoWrapperContainer {
 
     private final UserInfoWrapperBinding binding;
     private UserInfoWrapperState state;
-    private boolean isIconClicked;
 
     private final int MAX_LENGTH = 20;
 
     public UserInfoWrapperContainer(UserInfoWrapperBinding binding) {
         this.binding = binding;
         this.state = UserInfoWrapperState.READ;
-        this.isIconClicked = false;
 
         // 닉네임 자수 제한 검사
         binding.nicknameEdittext.addTextChangedListener(new TextWatcher() {
@@ -71,14 +69,6 @@ public class UserInfoWrapperContainer {
         updatePenIcon();
         updateEditText();
         updateWarningText();
-    }
-
-    public boolean isIconClicked() {
-        return isIconClicked;
-    }
-
-    public void setIconClicked(boolean isIconClicked) {
-        this.isIconClicked = isIconClicked;
     }
 
     private void updatePenIcon() {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
@@ -19,12 +19,14 @@ public class UserInfoWrapperContainer {
 
     private final UserInfoWrapperBinding binding;
     private UserInfoWrapperState state;
+    private boolean isIconClicked;
 
     private final int MAX_LENGTH = 20;
 
     public UserInfoWrapperContainer(UserInfoWrapperBinding binding) {
         this.binding = binding;
         this.state = UserInfoWrapperState.READ;
+        this.isIconClicked = false;
 
         // 닉네임 자수 제한 검사
         binding.nicknameEdittext.addTextChangedListener(new TextWatcher() {
@@ -69,6 +71,14 @@ public class UserInfoWrapperContainer {
         updatePenIcon();
         updateEditText();
         updateWarningText();
+    }
+
+    public boolean isIconClicked() {
+        return isIconClicked;
+    }
+
+    public void setIconClicked(boolean isIconClicked) {
+        this.isIconClicked = isIconClicked;
     }
 
     private void updatePenIcon() {
@@ -120,7 +130,7 @@ public class UserInfoWrapperContainer {
         binding.nicknameEdittext.setText(nickname);
     }
 
-    public void setCreatedAtText(long dayCount) {
+    public void setCreatedAtText(int dayCount) {
         int digit = Long.toString(dayCount).length();
         String text = "오늘까지 " + dayCount + "일째\n하루를 남기고 있어요";
         binding.createdAtText.setText(text);

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
@@ -131,7 +131,7 @@ public class UserInfoWrapperContainer {
     }
 
     public void setCreatedAtText(int dayCount) {
-        int digit = Long.toString(dayCount).length();
+        int digit = Integer.toString(dayCount).length();
         String text = "오늘까지 " + dayCount + "일째\n하루를 남기고 있어요";
         binding.createdAtText.setText(text);
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
@@ -26,15 +26,6 @@ public class UserInfoWrapperContainer {
         this.binding = binding;
         this.state = UserInfoWrapperState.READ;
 
-        // 수정 아이콘
-        binding.penIcon.setOnClickListener(v -> {
-            if (state == UserInfoWrapperState.READ) {
-                setState(UserInfoWrapperState.EDIT);
-            } else if (state == UserInfoWrapperState.EDIT) {
-                setState(UserInfoWrapperState.READ);
-            }
-        });
-
         // 닉네임 자수 제한 검사
         binding.nicknameEdittext.addTextChangedListener(new TextWatcher() {
             boolean isLimitExceeded = false;
@@ -61,6 +52,14 @@ public class UserInfoWrapperContainer {
                 }
             }
         });
+    }
+
+    public void setPenIconOnClickListener(View.OnClickListener listener) {
+        binding.penIcon.setOnClickListener(listener);
+    }
+
+    public UserInfoWrapperState getState() {
+        return state;
     }
 
     public void setState(UserInfoWrapperState state) {
@@ -113,12 +112,16 @@ public class UserInfoWrapperContainer {
         }
     }
 
+    public String getNickname() {
+        return binding.nicknameEdittext.getText().toString();
+    }
+
     public void setNickname(String nickname) {
         binding.nicknameEdittext.setText(nickname);
     }
 
-    public void setCreatedAtText(int dayCount) {
-        int digit = Integer.toString(dayCount).length();
+    public void setCreatedAtText(long dayCount) {
+        int digit = Long.toString(dayCount).length();
         String text = "오늘까지 " + dayCount + "일째\n하루를 남기고 있어요";
         binding.createdAtText.setText(text);
 

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/WriteViewFragment.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_writeview/WriteViewFragment.java
@@ -119,14 +119,8 @@ public class WriteViewFragment extends Fragment {
     }
 
     private int calculateNumPages() {
-        String dateInString = authenticationRepository.getCreatedAt();
-        if (dateInString.isBlank()) {
-            return 1;
-        }
+        LocalDate createdAt = authenticationRepository.getCreatedAt();
         LocalDate today = TimeConverter.getToday();
-        LocalDate createdAt = LocalDate.parse(dateInString.substring(0, 10));
-        int hour = Integer.parseInt(dateInString.substring(11, 13));
-        createdAt = TimeConverter.adjustToServiceDate(createdAt, hour);
 
         return (int) ChronoUnit.DAYS.between(createdAt, today) + 1;
     }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/TimeConverter.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/utils/TimeConverter.java
@@ -2,11 +2,13 @@ package snu.swpp.moment.utils;
 
 import android.util.Log;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
@@ -114,5 +116,16 @@ public class TimeConverter {
             result = result.minusDays(1);
         }
         return result;
+    }
+
+    public static String convertUTCToLocalTimeZone(String input) {
+        String dateTimeInString = input.substring(0, 19); // 초 단위까지만 끊어서 parsing
+
+        int SECONDS_PER_HOUR = 3600;
+        ZoneId localZoneId = ZoneId.systemDefault();
+        ZoneOffset offset = localZoneId.getRules().getOffset(Instant.now());
+        int hourDiff = offset.getTotalSeconds() / SECONDS_PER_HOUR; // 시차 계산
+
+        return LocalDateTime.parse(dateTimeInString).plusHours(hourDiff).toString();
     }
 }

--- a/frontend/Moment/app/src/main/res/layout/user_info_wrapper.xml
+++ b/frontend/Moment/app/src/main/res/layout/user_info_wrapper.xml
@@ -64,7 +64,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
         android:gravity="center"
-        android:text="@string/username_too_long"
+        android:text="@string/nickname_too_long"
 
         app:layout_constraintBottom_toTopOf="@id/created_at_text"
         app:layout_constraintEnd_toEndOf="@id/nickname_edittext"

--- a/frontend/Moment/app/src/main/res/values/strings.xml
+++ b/frontend/Moment/app/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="search_content_button">내용</string>
 
     <!-- 유저정보 탭 -->
-    <string name="username_too_long">닉네임은 20자까지만 쓸 수 있어요</string>
+    <string name="nickname_too_long">닉네임은 20자까지만 쓸 수 있어요</string>
+    <string name="nickname_update_success">닉네임이 변경되었습니다</string>
 
 </resources>

--- a/frontend/Moment/app/src/test/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModelTest.java
+++ b/frontend/Moment/app/src/test/java/snu/swpp/moment/ui/main_userinfoview/UserInfoViewModelTest.java
@@ -1,0 +1,104 @@
+package snu.swpp.moment.ui.main_userinfoview;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.lifecycle.LiveData;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import snu.swpp.moment.data.callback.NicknameCallBack;
+import snu.swpp.moment.data.callback.TokenCallBack;
+import snu.swpp.moment.data.model.TokenModel;
+import snu.swpp.moment.data.repository.AuthenticationRepository;
+import snu.swpp.moment.data.source.UserLocalDataSource;
+import snu.swpp.moment.data.source.UserRemoteDataSource;
+import snu.swpp.moment.exception.UnauthorizedAccessException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UserInfoViewModelTest {
+
+    private UserInfoViewModel viewModel;
+
+    @Mock
+    private UserLocalDataSource localDataSource;
+    @Mock
+    private UserRemoteDataSource remoteDataSource;
+
+    @Spy
+    @InjectMocks
+    private AuthenticationRepository repository;
+
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    @Before
+    public void setUp() {
+        doAnswer(invocation -> {
+            TokenCallBack callback = (TokenCallBack) invocation.getArguments()[0];
+            callback.onSuccess();
+            return null;
+        }).when(repository).isTokenValid(any());
+        doReturn(new TokenModel("access", "refresh")).when(repository).getToken();
+
+        viewModel = new UserInfoViewModel(repository);
+    }
+
+    @Test
+    public void updateNickname_success() {
+        // Given
+        final String nickname = "nickname";
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            NicknameCallBack callback = (NicknameCallBack) args[2];
+            callback.onSuccess(nickname);
+            return null;
+        }).when(remoteDataSource).updateNickname(anyString(), anyString(), any());
+
+        viewModel.getNicknameUpdateErrorState().observeForever(errorState -> {
+        });
+
+        // When
+        viewModel.updateNickname(nickname);
+
+        // Then
+        LiveData<NicknameUpdateErrorState> errorState = viewModel.getNicknameUpdateErrorState();
+        System.out.println(errorState.getValue());
+        assertNull(errorState.getValue().getError());
+        assertEquals(nickname, viewModel.getNickname());
+    }
+
+    @Test
+    public void updateNickname_fail() {
+        // Given
+        final String nickname = "nickname";
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            NicknameCallBack callback = (NicknameCallBack) args[2];
+            callback.onFailure(new UnauthorizedAccessException());
+            return null;
+        }).when(remoteDataSource).updateNickname(anyString(), anyString(), any());
+
+        viewModel.getNicknameUpdateErrorState().observeForever(errorState -> {
+        });
+
+        // When
+        viewModel.updateNickname(nickname);
+
+        // Then
+        LiveData<NicknameUpdateErrorState> errorState = viewModel.getNicknameUpdateErrorState();
+        assertNotNull(errorState.getValue().getError());
+        assertEquals("토큰이 만료되었습니다.", errorState.getValue().getError().getMessage());
+    }
+}

--- a/frontend/Moment/app/src/test/java/snu/swpp/moment/utils/TimeConverterTest.java
+++ b/frontend/Moment/app/src/test/java/snu/swpp/moment/utils/TimeConverterTest.java
@@ -192,4 +192,15 @@ public class TimeConverterTest {
         cur = LocalDateTime.of(2023, 11, 3, 3, 0, 0);
         assertTrue(TimeConverter.hasDayPassed(base, cur));
     }
+
+    @Test
+    public void convertUTCToLocalTimeZone() {
+        LocalDateTime utcDateTime = LocalDateTime.of(2023, 10, 13, 17, 16, 47);
+        String utcDateTimeInString = utcDateTime.toString() + ".210625Z"; // "2023-10-13T17:16:47.210625Z"
+
+        LocalDateTime localDateTime = utcDateTime.plusHours(hourDiff);
+        String answer = localDateTime.toString();
+
+        assertEquals(answer, TimeConverter.convertUTCToLocalTimeZone(utcDateTimeInString));
+    }
 }


### PR DESCRIPTION
### PR Title: 프론트 - 유저 정보 탭 API & local data 연결

#### PR Description: 
1. 유저 닉네임 변경 API에서는 UTC로 회원가입 일자를 보내주고 있어서 이를 현지 시간에 맞추는 코드 및 유닛 테스트 추가
2. 성공, 실패 시 토스트를 통해 성공 여부 전달
3. ViewModel 유닛 테스트 완료

#### Additional Comments: 
None
