### PR TITLE
Frontend/A3: 내정보 탭 UI testing

### DIFF
--- a/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
+++ b/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
@@ -1,6 +1,7 @@
 package snu.swpp.moment;
 
 import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
@@ -71,5 +72,14 @@ public class UserInfoViewTest {
             .check(matches(withTagValue(equalTo(R.drawable.pen))));
         // 닉네임 입력창이 not clickable 상태가 됨
         onView(withId(R.id.nickname_edittext)).check(matches(isNotEnabled()));
+    }
+
+    @Test
+    public void whenNicknameLengthLimitExceeded_WarningIsDisplayed() {
+        onView(withId(R.id.pen_icon)).perform(forceClick());
+        onView(withId(R.id.nickname_edittext)).perform(forceClick(),
+            replaceText("닉네임!닉네임!닉네임!닉네임!닉네임!닉네임!"));
+        // 경고 문구 표시됨
+        onView(withId(R.id.nickname_length_warning_text)).check(matches(isDisplayed()));
     }
 }

--- a/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
+++ b/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
@@ -58,7 +58,7 @@ public class UserInfoViewTest {
         onView(withId(R.id.pen_icon)).perform(forceClick());
         // pen icon이 저장 버튼으로 바뀜
         onView(withId(R.id.pen_icon))
-            .check(matches(withTagValue(equalTo(R.drawable.moment_add_button))));
+            .check(matches(withTagValue(equalTo(R.drawable.moment_write_button))));
         // 닉네임 입력창이 clickable 상태가 됨
         onView(withId(R.id.nickname_edittext)).check(matches(isEnabled()));
     }

--- a/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
+++ b/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
@@ -1,0 +1,75 @@
+package snu.swpp.moment;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
+import static androidx.test.espresso.matcher.ViewMatchers.isNotEnabled;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
+import static org.hamcrest.Matchers.equalTo;
+import static snu.swpp.moment.utils.CustomViewActions.forceClick;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+import androidx.test.espresso.contrib.DrawerActions;
+import androidx.test.espresso.contrib.NavigationViewActions;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import snu.swpp.moment.ui.login.LoginActivity;
+import snu.swpp.moment.utils.LoginAction;
+
+@RunWith(AndroidJUnit4.class)
+public class UserInfoViewTest {
+
+    @Rule
+    public ActivityScenarioRule<LoginActivity> scenarioRule = new ActivityScenarioRule<>(
+        LoginActivity.class);
+    @Rule
+    public InstantTaskExecutorRule instantTaskExecutorRule = new InstantTaskExecutorRule();
+
+    @Before
+    public void setUp() {
+        LoginAction.setUp();
+        onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
+        onView(withId(R.id.nav_view))
+            .perform(NavigationViewActions.navigateTo(R.id.UserInfoView));
+    }
+
+    @After
+    public void tearDown() {
+        LoginAction.tearDown();
+    }
+
+    @Test
+    public void whenUserInfoViewFragmentLaunched_ViewComponentsAreDisplayed() {
+        onView(withId(R.id.user_info_wrapper)).check(matches(isDisplayed()));
+        onView(withId(R.id.logout_button)).check(matches(isDisplayed()));
+        onView(withId(R.id.logo)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void whenPenIconClicked_EditModeIsActivated() {
+        onView(withId(R.id.pen_icon)).perform(forceClick());
+        // pen icon이 저장 버튼으로 바뀜
+        onView(withId(R.id.pen_icon))
+            .check(matches(withTagValue(equalTo(R.drawable.moment_add_button))));
+        // 닉네임 입력창이 clickable 상태가 됨
+        onView(withId(R.id.nickname_edittext)).check(matches(isEnabled()));
+    }
+
+    @Test
+    public void whenPenIconClickedTwice_ViewModeIsActivated() {
+        onView(withId(R.id.pen_icon)).perform(forceClick());
+        onView(withId(R.id.pen_icon)).perform(forceClick());
+        // pen icon이 펜 모양으로 바뀜
+        onView(withId(R.id.pen_icon))
+            .check(matches(withTagValue(equalTo(R.drawable.pen))));
+        // 닉네임 입력창이 not clickable 상태가 됨
+        onView(withId(R.id.nickname_edittext)).check(matches(isNotEnabled()));
+    }
+}

--- a/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
+++ b/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/UserInfoViewTest.java
@@ -79,6 +79,9 @@ public class UserInfoViewTest {
         onView(withId(R.id.pen_icon)).perform(forceClick());
         onView(withId(R.id.nickname_edittext)).perform(forceClick(),
             replaceText("닉네임!닉네임!닉네임!닉네임!닉네임!닉네임!"));
+        // 저장 버튼이 비활성화됨
+        onView(withId(R.id.pen_icon))
+            .check(matches(withTagValue(equalTo(R.drawable.moment_write_inactivate))));
         // 경고 문구 표시됨
         onView(withId(R.id.nickname_length_warning_text)).check(matches(isDisplayed()));
     }

--- a/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/utils/DisableAutoFillAction.java
+++ b/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/utils/DisableAutoFillAction.java
@@ -1,0 +1,35 @@
+package snu.swpp.moment.utils;
+
+import android.os.Build;
+import android.view.View;
+import android.view.autofill.AutofillManager;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+public class DisableAutoFillAction implements ViewAction {
+
+    @Override
+    public Matcher<View> getConstraints() {
+        return Matchers.any(View.class);
+    }
+
+    @Override
+    public String getDescription() {
+        return "Dismissing autofill picker";
+    }
+
+    @Override
+    public void perform(UiController uiController, View view) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
+            AutofillManager autofillManager = view.getContext()
+                .getSystemService(AutofillManager.class);
+
+            if (autofillManager != null) {
+                autofillManager.cancel();
+            }
+        }
+    }
+}

--- a/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/utils/LoginAction.java
+++ b/frontend/Moment/app/src/androidTest/java/snu/swpp/moment/utils/LoginAction.java
@@ -35,8 +35,10 @@ public class LoginAction {
     }
 
     private static void login() {
-        onView(withId(R.id.username)).perform(click(), replaceText(username));
-        onView(withId(R.id.password)).perform(click(), replaceText(password));
+        onView(withId(R.id.username)).perform(new DisableAutoFillAction(), click(),
+            replaceText(username));
+        onView(withId(R.id.password)).perform(new DisableAutoFillAction(), click(),
+            replaceText(password));
         onView(withId(R.id.login_button)).perform(forceClick());
     }
 }

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
@@ -87,6 +87,7 @@ public class UserInfoWrapperContainer {
                 setPenIconImage(R.drawable.moment_write_inactivate);
                 break;
         }
+        Log.d("UserInfoWrapperContainer", "updatePenIcon: " + binding.penIcon.getTag());
     }
 
     private void setPenIconImage(@DrawableRes int resId) {

--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/ui/main_userinfoview/UserInfoWrapperContainer.java
@@ -7,6 +7,7 @@ import android.text.TextWatcher;
 import android.text.style.ForegroundColorSpan;
 import android.util.Log;
 import android.view.View;
+import androidx.annotation.DrawableRes;
 import androidx.core.content.ContextCompat;
 import snu.swpp.moment.R;
 import snu.swpp.moment.databinding.UserInfoWrapperBinding;
@@ -75,17 +76,22 @@ public class UserInfoWrapperContainer {
         switch (state) {
             case READ:
                 binding.penIcon.setEnabled(true);
-                binding.penIcon.setImageResource(R.drawable.pen);
+                setPenIconImage(R.drawable.pen);
                 break;
             case EDIT:
                 binding.penIcon.setEnabled(true);
-                binding.penIcon.setImageResource(R.drawable.moment_write_button);
+                setPenIconImage(R.drawable.moment_write_button);
                 break;
             case EDIT_LIMIT_EXCEEDED:
                 binding.penIcon.setEnabled(false);
-                binding.penIcon.setImageResource(R.drawable.moment_write_inactivate);
+                setPenIconImage(R.drawable.moment_write_inactivate);
                 break;
         }
+    }
+
+    private void setPenIconImage(@DrawableRes int resId) {
+        binding.penIcon.setImageResource(resId);
+        binding.penIcon.setTag(resId);  // for UI testing
     }
 
     private void updateEditText() {


### PR DESCRIPTION
### Frontend/A3: 내정보 탭 UI testing

#### PR Description: 
내정보 탭 UI testing 코드를 작성했습니다.

test cases:
1. 탭 진입 시 view들이 잘 보이는지
2. 펜 아이콘 누르면 수정모드로 잘 바뀌는지
3. 한번 더 누르면 다시 원래대로 돌아오는지

그 외 수정 사항:
* pen icon의 image resource가 바뀌는지 검사하기 위해서 tag 설정을 추가했습니다.
* UI testing 중 로그인 단계에서 비밀번호 자동완성을 비활성화하도록 했습니다.

#### Additional Comments: 
None
