### PR TITLE
Frontend/a5: toolbar 날짜 수정

### DIFF
--- a/frontend/Moment/app/src/main/java/snu/swpp/moment/MainActivity.java
+++ b/frontend/Moment/app/src/main/java/snu/swpp/moment/MainActivity.java
@@ -108,7 +108,7 @@ public class MainActivity extends AppCompatActivity {
         });
 
         //Wirte View의 타이틀이 항상 날짜로 나오도록 NavController의 타이틀 업데이트 비활성화:
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy. MM. dd.", Locale.getDefault());
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy. MM. dd. E", Locale.KOREA);//다른 탭 갔다 왔을 때 요일이 잠시 영어로 보이는 문제 해결 위해 Locale을 직접 지정
         String currentDate = sdf.format(new Date());
         System.out.println("#Debug Mainactivity date ok");
 


### PR DESCRIPTION
### PR Title: toolbar 날짜 수정

#### PR Description: 
mainactivity에서 탭 별로 제목을 줄때 요일을 안 주고 있었어서 수정했습니다.
#### Additional Comments: 
이것 때문에 요일이 안 보인 것 맞는 것 같은데 왜 날짜까지 안보였는지는 모르겠네요. 일단 전 날짜가 안 보이는 건 재현이 안 되었고 수정 후에는 요일은 잘 보입니다.