### PR TITLE
Backend/search fix 검색 timezone 이슈 수정

### DIFF
--- a/backend/moment/writing/search_views.py
+++ b/backend/moment/writing/search_views.py
@@ -131,13 +131,19 @@ class ContentSearchView(GenericAPIView):
     def _day_start_end(
         time: datetime.datetime,
     ) -> Tuple[datetime.datetime, datetime.datetime]:
-        if time.hour < 3:
-            time = time - datetime.timedelta(days=1)
-        start_time = time.replace(hour=3, minute=0, second=0)
-        end_time = (
-            start_time + datetime.timedelta(days=1) - datetime.timedelta(seconds=1)
+        HOUR_DIFF = 9
+        local_time = time + datetime.timedelta(hours=HOUR_DIFF)
+        if local_time.hour < 3:
+            local_time = local_time - datetime.timedelta(days=1)
+        local_start_time = local_time.replace(hour=3, minute=0, second=0)
+        local_end_time = (
+            local_start_time
+            + datetime.timedelta(days=1)
+            - datetime.timedelta(seconds=1)
         )
-        return start_time, end_time
+        return local_start_time - datetime.timedelta(
+            hours=HOUR_DIFF
+        ), local_end_time - datetime.timedelta(hours=HOUR_DIFF)
 
     @staticmethod
     def _search_moments(

--- a/backend/moment/writing/tests/search_tests.py
+++ b/backend/moment/writing/tests/search_tests.py
@@ -171,16 +171,18 @@ class HashtagSearchTest(TestCase):
 
 
 class ContentSearchTest(TestCase):
+    HOUR_DIFF = 9
+
     def setUp(self):
         user1 = User.objects.create(username="test1")
         user2 = User.objects.create(username="test2")
 
         day_start = datetime.datetime(
             year=2023, month=11, day=3, hour=3, minute=0, second=0
-        )
+        ) - datetime.timedelta(hours=self.HOUR_DIFF)
         day_end = datetime.datetime(
             year=2023, month=11, day=4, hour=2, minute=59, second=59
-        )
+        ) - datetime.timedelta(hours=self.HOUR_DIFF)
         story1 = Story.objects.create(
             created_at=day_end,
             user=user1,
@@ -252,8 +254,11 @@ class ContentSearchTest(TestCase):
         self.assertEqual(entries[0]["field"], SearchFields.MOMENT)
         self.assertEqual(
             entries[0]["created_at"],
-            datetime.datetime(
-                year=2023, month=11, day=6, hour=2, minute=59, second=59
+            (
+                datetime.datetime(
+                    year=2023, month=11, day=6, hour=2, minute=59, second=59
+                )
+                - datetime.timedelta(hours=self.HOUR_DIFF)
             ).timestamp(),
         )
         self.assertEqual(entries[0]["title"], "검색모먼트")


### PR DESCRIPTION
### PR Title:검색 timezone 이슈 수정

#### PR Description: 
내용 검색시 모먼트를 받아올 때 하루의 시작과 끝을 계산하는 과정에서 timezone을 고려하지 않은 문제가 있었어서 수정했습니다.
#### Additional Comments: 
None